### PR TITLE
fix(fixtures): make madcoders_rma_order_return fixture loadable (#9) + fixtures-runnable CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,54 @@ jobs:
             - name: PHPUnit
               run: make phpunit
 
+    fixtures:
+        name: Fixtures runnable (sylius:fixtures:load)
+        runs-on: ubuntu-latest
+        services:
+            # Same MySQL service as the Behat job (see docker-compose.yml): the test app's
+            # DATABASE_URL and the make targets work unchanged.
+            mysql:
+                image: mysql:8.0
+                env:
+                    MYSQL_ROOT_PASSWORD: rma
+                ports:
+                    - "3307:3306"
+                options: >-
+                    --health-cmd="mysqladmin ping -h 127.0.0.1 -prma"
+                    --health-interval=5s
+                    --health-timeout=5s
+                    --health-retries=20
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: "${{ env.PHP_VERSION }}"
+                  extensions: intl, pdo_mysql, zip, gd
+                  tools: composer:v2
+                  coverage: none
+
+            - name: Get Composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+            - name: Cache Composer dependencies
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: composer-${{ env.PHP_VERSION }}-${{ hashFiles('composer.json') }}
+                  restore-keys: composer-${{ env.PHP_VERSION }}-
+
+            - name: Install dependencies
+              run: composer update --no-interaction --no-progress --prefer-dist
+
+            - name: Create the test database
+              run: make backend-test
+
+            - name: Load the default fixtures suite
+              run: make fixtures-test
+
     behat:
         name: Behat (non-JavaScript)
         runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help \
         install update setup init app \
         docker-up docker-up-all docker-down docker-logs \
-        backend backend-test frontend cache-clean db-reset fixtures serve serve-test \
+        backend backend-test frontend cache-clean db-reset fixtures fixtures-test serve serve-test \
         test phpunit behat behat-js \
         static rector rector-fix phpstan ecs fix \
         verify pre-commit install-hooks \
@@ -63,6 +63,9 @@ db-reset: ## Drop and recreate the database schema
 
 fixtures: ## (Re)load the default Sylius + RMA fixtures
 	$(TEST_APP)/bin/console sylius:fixtures:load default --no-interaction
+
+fixtures-test: ## Load the default Sylius + RMA fixtures into the test database (used by CI)
+	APP_ENV=test $(TEST_APP)/bin/console sylius:fixtures:load default --no-interaction
 
 serve: ## Serve the local DEV application on https://127.0.0.1:8080 (dev database)
 	APP_ENV=dev $(TEST_APP)/bin/console cache:clear

--- a/src/Fixture/Factory/OrderReturnConsentFixtureFactory.php
+++ b/src/Fixture/Factory/OrderReturnConsentFixtureFactory.php
@@ -45,7 +45,7 @@ final class OrderReturnConsentFixtureFactory extends AbstractExampleFactory impl
         Assert::string($options['code']);
         Assert::string($options['name']);
         Assert::string($options['slug']);
-        Assert::string($options['description']);
+        Assert::nullOrString($options['description']);
 
         $orderReturnConsent = new OrderReturnConsent();
         $orderReturnConsent->setCurrentLocale($options['current_locale']);

--- a/src/Fixture/Factory/OrderReturnFixtureFactory.php
+++ b/src/Fixture/Factory/OrderReturnFixtureFactory.php
@@ -60,7 +60,7 @@ final class OrderReturnFixtureFactory extends AbstractExampleFactory implements 
         Assert::string($options['street']);
         Assert::string($options['phone_number']);
         Assert::string($options['customer_ip']);
-        Assert::string($options['customer_number']);
+        Assert::scalar($options['customer_number']);
 
         $channelCode = $options['channel_code'];
 
@@ -81,7 +81,7 @@ final class OrderReturnFixtureFactory extends AbstractExampleFactory implements 
         $orderReturn->setStreet($options['street']);
         $orderReturn->setPhoneNumber($options['phone_number']);
         $orderReturn->setCustomerIp($options['customer_ip']);
-        $orderReturn->setCustomerNumber($options['customer_number']);
+        $orderReturn->setCustomerNumber((string) $options['customer_number']);
 
         return $orderReturn;
     }
@@ -123,7 +123,7 @@ final class OrderReturnFixtureFactory extends AbstractExampleFactory implements 
             ->setAllowedTypes('phone_number', 'string')
 
             ->setRequired('customer_number')
-            ->setAllowedTypes('customer_number', 'integer')
+            ->setAllowedTypes('customer_number', ['integer', 'string'])
         ;
     }
 }

--- a/src/Fixture/Factory/OrderReturnReasonFixtureFactory.php
+++ b/src/Fixture/Factory/OrderReturnReasonFixtureFactory.php
@@ -45,7 +45,7 @@ final class OrderReturnReasonFixtureFactory extends AbstractExampleFactory imple
         Assert::integer($options['deadline_to_return']);
         Assert::string($options['name']);
         Assert::string($options['slug']);
-        Assert::string($options['description']);
+        Assert::nullOrString($options['description']);
 
         $orderReturnReason = new OrderReturnReason();
         $orderReturnReason->setCurrentLocale('en_US');

--- a/tests/Application/config/packages/madcoders_default_fixtures.yaml
+++ b/tests/Application/config/packages/madcoders_default_fixtures.yaml
@@ -2,15 +2,16 @@ sylius_fixtures:
     suites:
         default:
             fixtures:
-#                madcoders_rma_order_return:
-#                    options:
-#                        custom:
-#                            draft_order_return:
-#                                order_number: "000000011"
-#                                return_number: "R00000011-1"
-#                                channel_code: "FASHION_WEB"
-#                                return_reason: "damaged"
-#
+                madcoders_rma_order_return:
+                    options:
+                        custom:
+                            draft_order_return:
+                                order_number: "000000011"
+                                return_number: "R00000011-1"
+                                channel_code: "FASHION_WEB"
+                                return_reason: "damaged"
+                                customer_number: 1
+
 #                madcoders_rma_order_return_item:
 #                    options:
 #                        custom:

--- a/tests/Unit/Fixture/Factory/OrderReturnConsentFixtureFactoryTest.php
+++ b/tests/Unit/Fixture/Factory/OrderReturnConsentFixtureFactoryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Madcoders\SyliusRmaPlugin\Unit\Fixture\Factory;
+
+use Madcoders\SyliusRmaPlugin\Entity\OrderReturnConsentInterface;
+use Madcoders\SyliusRmaPlugin\Fixture\Factory\OrderReturnConsentFixtureFactory;
+use Tests\Madcoders\SyliusRmaPlugin\Unit\UnitTestCase;
+
+class OrderReturnConsentFixtureFactoryTest extends UnitTestCase
+{
+    /** @test */
+    function it_creates_a_consent_without_a_description()
+    {
+        // description is optional (defaults to null); the fixture must still load
+        $consent = (new OrderReturnConsentFixtureFactory())->create([
+            'code' => 'consent_1',
+            'name' => 'Consent 1',
+            'slug' => 'consent_1',
+        ]);
+
+        $this->assertInstanceOf(OrderReturnConsentInterface::class, $consent);
+        $this->assertNull($consent->getDescription());
+    }
+
+    /** @test */
+    function it_creates_a_consent_with_a_description()
+    {
+        $consent = (new OrderReturnConsentFixtureFactory())->create([
+            'code' => 'consent_1',
+            'name' => 'Consent 1',
+            'slug' => 'consent_1',
+            'description' => 'Some description',
+        ]);
+
+        $this->assertSame('Some description', $consent->getDescription());
+    }
+}

--- a/tests/Unit/Fixture/Factory/OrderReturnFixtureFactoryTest.php
+++ b/tests/Unit/Fixture/Factory/OrderReturnFixtureFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Madcoders\SyliusRmaPlugin\Unit\Fixture\Factory;
+
+use Madcoders\SyliusRmaPlugin\Entity\OrderReturnInterface;
+use Madcoders\SyliusRmaPlugin\Fixture\Factory\OrderReturnFixtureFactory;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Tests\Madcoders\SyliusRmaPlugin\Unit\UnitTestCase;
+
+class OrderReturnFixtureFactoryTest extends UnitTestCase
+{
+    use ProphecyTrait;
+
+    /** @test */
+    function it_creates_an_order_return_from_an_integer_customer_number()
+    {
+        // the shipped fixtures (and the documented option type) pass customer_number as an integer
+        $orderReturn = $this->factoryWithChannel('FASHION_WEB')
+            ->create($this->baseOptions() + ['customer_number' => 4]);
+
+        $this->assertInstanceOf(OrderReturnInterface::class, $orderReturn);
+        $this->assertSame('4', $orderReturn->getCustomerNumber());
+    }
+
+    /** @test */
+    function it_accepts_a_string_customer_number()
+    {
+        $orderReturn = $this->factoryWithChannel('FASHION_WEB')
+            ->create($this->baseOptions() + ['customer_number' => '4']);
+
+        $this->assertSame('4', $orderReturn->getCustomerNumber());
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function baseOptions(): array
+    {
+        return [
+            'channel_code' => 'FASHION_WEB',
+            'order_number' => '000000001',
+            'return_number' => 'RMA-000000001-1',
+            'return_reason' => 'free-return-14',
+        ];
+    }
+
+    private function factoryWithChannel(string $code): OrderReturnFixtureFactory
+    {
+        $channelRepository = $this->prophesize(ChannelRepositoryInterface::class);
+        $channelRepository->findOneByCode($code)->willReturn($this->prophesize(ChannelInterface::class)->reveal());
+
+        return new OrderReturnFixtureFactory($channelRepository->reveal());
+    }
+}

--- a/tests/Unit/Fixture/Factory/OrderReturnReasonFixtureFactoryTest.php
+++ b/tests/Unit/Fixture/Factory/OrderReturnReasonFixtureFactoryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Madcoders\SyliusRmaPlugin\Unit\Fixture\Factory;
+
+use Madcoders\SyliusRmaPlugin\Entity\OrderReturnReasonInterface;
+use Madcoders\SyliusRmaPlugin\Fixture\Factory\OrderReturnReasonFixtureFactory;
+use Tests\Madcoders\SyliusRmaPlugin\Unit\UnitTestCase;
+
+class OrderReturnReasonFixtureFactoryTest extends UnitTestCase
+{
+    /** @test */
+    function it_creates_a_reason_without_a_description()
+    {
+        // description is optional (defaults to null); the fixture must still load
+        $reason = (new OrderReturnReasonFixtureFactory())->create([
+            'code' => 'reason_1',
+            'name' => 'Reason 1',
+            'slug' => 'reason_1',
+            'deadline_to_return' => 14,
+        ]);
+
+        $this->assertInstanceOf(OrderReturnReasonInterface::class, $reason);
+        $this->assertNull($reason->getDescription());
+    }
+
+    /** @test */
+    function it_creates_a_reason_with_a_description()
+    {
+        $reason = (new OrderReturnReasonFixtureFactory())->create([
+            'code' => 'reason_1',
+            'name' => 'Reason 1',
+            'slug' => 'reason_1',
+            'deadline_to_return' => 14,
+            'description' => 'Some description',
+        ]);
+
+        $this->assertSame('Some description', $reason->getDescription());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #9 - the shipped `madcoders_rma_order_return` fixture could never load. The `OptionsResolver` required `customer_number` to be an **integer**, but the value was asserted as a **string** and passed to `OrderReturn::setCustomerNumber(string)`. No value satisfied both gates (an int tripped `Assert::string`, a string tripped the `OptionsResolver` allowed-type), so the fixture was unusable.

While adding a CI gate that actually loads the fixtures suite end-to-end, two more fixtures of the same bug family surfaced (optional `description` declared `string|null` but asserted `Assert::string`), so they are fixed here too.

## Changes

- **Fix #9** - `OrderReturnFixtureFactory`: accept `['integer', 'string']` for `customer_number` and cast to string before the setter, matching `ReturnRequestBuilder`'s real-flow `(string) $customer->getId()`.
- **Collateral fixes** - `OrderReturnReasonFixtureFactory` and `OrderReturnConsentFixtureFactory`: use `Assert::nullOrString` for the optional `description` (the entity setters already accept `?string`). Without this, loading the default suite throws `Expected a string. Got: NULL`.
- **Fixtures-runnable CI gate** - a new `fixtures` job provisions MySQL, creates the test DB, and runs `sylius:fixtures:load default` (new `make fixtures-test` target). The previously commented-out `madcoders_rma_order_return` block in the default suite is enabled so the gate exercises the RMA order-return fixture. This is what would have caught #9.

## Tests

Unit-first (red -> green):

- `OrderReturnFixtureFactoryTest` - integer and string `customer_number` both produce an `OrderReturn` with `customerNumber === '4'`.
- `OrderReturnReasonFixtureFactoryTest` / `OrderReturnConsentFixtureFactoryTest` - create with and without a `description`.

Verified locally: 26 unit tests pass; PHPStan (level max), ECS, and Rector dry-run clean; and `make fixtures-test` loads the full default suite end-to-end against MySQL (`EXIT=0`), with all three RMA fixtures loading.

## Backmerge

Both defects also affect `1.1` (verified). This targets `1.2`; it can be backmerged to `1.1` afterwards.