### PR TITLE
feat(returns): flag products as non-returnable (item-level return eligibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,34 +122,28 @@ ticked:
 - the flag removes the line regardless of remaining quantity.
 
 Out of the box every product is returnable. To enable the flag, have your Sylius `Product` model
-implement [`NonReturnableProductInterface`](src/Entity/NonReturnableProductInterface.php), backed by
-a `non_returnable` boolean column (the plugin migration adds it to `sylius_product`):
+implement [`NonReturnableProductInterface`](src/Entity/NonReturnableProductInterface.php) and apply
+[`NonReturnableProductTrait`](src/Entity/NonReturnableProductTrait.php) (the trait supplies the
+`non_returnable` column and accessors):
 
 ```php
 // src/Entity/Product/Product.php
 use Doctrine\ORM\Mapping as ORM;
 use Madcoders\SyliusRmaPlugin\Entity\NonReturnableProductInterface;
+use Madcoders\SyliusRmaPlugin\Entity\NonReturnableProductTrait;
 use Sylius\Component\Core\Model\Product as BaseProduct;
 
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_product')]
 class Product extends BaseProduct implements NonReturnableProductInterface
 {
-    #[ORM\Column(name: 'non_returnable', type: 'boolean', options: ['default' => false])]
-    protected bool $nonReturnable = false;
-
-    public function isNonReturnable(): bool
-    {
-        return $this->nonReturnable;
-    }
-
-    public function setNonReturnable(bool $nonReturnable): void
-    {
-        $this->nonReturnable = $nonReturnable;
-    }
+    use NonReturnableProductTrait;
 }
 ```
 
-The checkbox is added to the admin product form automatically (a form-type extension, rendered via
-the `sylius.admin.product.tab_details` template event) once the model implements the interface. To
+Then run the plugin migration (it adds the `non_returnable` column to `sylius_product`). The
+checkbox is added to the admin product form automatically (a form-type extension, rendered via the
+`sylius.admin.product.tab_details` template event) once the model implements the interface. To
 source the flag from somewhere other than the product entity, replace
 [`ProductReturnabilityCheckerInterface`](#customizations).
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,53 @@ madcoders_rma:
 
 When disabled, an unpaid order is not offered the withdrawal flow at all.
 
+### Optional: mark products as non-returnable
+
+Some products cannot be taken back (perishables, hygiene/sealed goods, made-to-order items, gift
+cards). Return eligibility is normally decided per order; this adds an **item-level** rule so such
+products are excluded from the return flow even on an otherwise returnable order.
+
+Once enabled (see below), the admin product form gains a **"Non-returnable"** checkbox. With it
+ticked:
+
+- a variant of that product is never offered for return and is never persisted onto an
+  `OrderReturn`;
+- an order whose items are **all** non-returnable shows "nothing to return" (the start-return button
+  is hidden), exactly like an ineligible order;
+- the flag removes the line regardless of remaining quantity.
+
+Out of the box every product is returnable. To enable the flag, have your Sylius `Product` model
+implement [`NonReturnableProductInterface`](src/Entity/NonReturnableProductInterface.php), backed by
+a `non_returnable` boolean column (the plugin migration adds it to `sylius_product`):
+
+```php
+// src/Entity/Product/Product.php
+use Doctrine\ORM\Mapping as ORM;
+use Madcoders\SyliusRmaPlugin\Entity\NonReturnableProductInterface;
+use Sylius\Component\Core\Model\Product as BaseProduct;
+
+class Product extends BaseProduct implements NonReturnableProductInterface
+{
+    #[ORM\Column(name: 'non_returnable', type: 'boolean', options: ['default' => false])]
+    protected bool $nonReturnable = false;
+
+    public function isNonReturnable(): bool
+    {
+        return $this->nonReturnable;
+    }
+
+    public function setNonReturnable(bool $nonReturnable): void
+    {
+        $this->nonReturnable = $nonReturnable;
+    }
+}
+```
+
+The checkbox is added to the admin product form automatically (a form-type extension, rendered via
+the `sylius.admin.product.tab_details` template event) once the model implements the interface. To
+source the flag from somewhere other than the product entity, replace
+[`ProductReturnabilityCheckerInterface`](#customizations).
+
 ## Returns state machine
 
 Every return form is an `OrderReturn` entity driven by a single
@@ -221,6 +268,7 @@ change a rule for the whole plugin by pointing the alias at your own implementat
 | `Withdrawal\WithdrawalEligibilityCheckerInterface` | `isWithdrawable(OrderInterface)` | whether a (pre-shipment) order is offered withdrawal at all | `.withdrawal.eligibility_checker` |
 | `Withdrawal\InstantCancellationEligibilityCheckerInterface` | `isEligible(OrderInterface)` | within withdrawal, instant (unpaid) vs admin approval (paid) | `.withdrawal.instant_cancellation_eligibility_checker` |
 | `Reason\ReturnReasonEligibilityCheckerInterface` | `isEligible(OrderInterface, OrderReturnReasonInterface)` | whether a given return reason is offered (deadline since shipment) | `.reason.return_reason_eligibility_checker` |
+| `ProductReturnabilityCheckerInterface` | `isReturnable(ProductVariantInterface)` | whether a single ordered variant may be added to a return (item-level) | `.product_returnability_checker` |
 
 To replace one, implement its interface and alias it in your application:
 

--- a/ai/tasks/14-non-returnable-items.md
+++ b/ai/tasks/14-non-returnable-items.md
@@ -1,0 +1,61 @@
+# Task 14 - Flag selected products/variants as non-returnable (item-level eligibility)
+
+**Goal:** Let merchants mark selected products/variants as **non-returnable** so those items
+are excluded from the customer return request, layered on top of the existing order-level
+eligibility. Status: **planned.**
+Tracking issue: [mad-coders/sylius-rma-plugin#18](https://github.com/mad-coders/sylius-rma-plugin/issues/18).
+
+## Background
+Return eligibility today is decided **per order**, never per product. Whether an order can be
+returned depends on order state, shipment, and the per-reason deadline window
+(`src/Services/ReturnEligibilityChecker.php:33`,
+`src/Services/Reason/ReturnReasonEligibilityChecker.php:38`), and each order item is offered
+up to its remaining quantity (`src/Services/MaxQtyCalculator.php:29`, used in
+`src/Services/ReturnRequestBuilder.php:110-126`). There is no way to say "this product can
+never be returned". Merchants selling perishables, hygiene/sealed goods, made-to-order items
+or gift cards must reject such returns manually after the fact.
+
+## Scope
+Add an **item-level returnability** check that sits alongside (does not replace) the
+order-level checks. A non-returnable variant is removed from the return flow entirely,
+regardless of remaining quantity. Default behaviour is unchanged: with nothing configured,
+every variant is returnable (backward compatible).
+
+- A non-returnable item is **not** rendered as a selectable line on the customer return form
+  (shop and account flows) and is **not** persisted onto an `OrderReturn`.
+- An order made up **only** of non-returnable items yields the same "nothing to return"
+  outcome as an ineligible order (no empty/partial return created).
+- Returnability is independent of quantity - the flag removes the line outright.
+
+## Implementation outline
+- **Checker interface:** add `ProductReturnabilityCheckerInterface::isReturnable(ProductVariantInterface): bool`
+  with a default implementation; alias the interface to the default in DI so integrators can
+  replace/decorate it without editing plugin code (mirror the overridable eligibility-checker
+  pattern in the README "Customizations" chapter and the interface-backed service proposed in
+  #15).
+- **Builder integration:** consult the checker inside `ReturnRequestBuilder::build()` while
+  iterating `$order->getItems()` (`src/Services/ReturnRequestBuilder.php:110`), skipping
+  non-returnable variants before `new OrderReturnItem()` (`:126`); this also drops them from
+  the form's `items` collection (`src/Form/Type/ReturnFormType.php:44`).
+- **Flag storage** (pick one in implementation; default = returnable):
+  - preferred: a Sylius **product attribute / boolean** (no core entity change,
+    merchant-configurable in admin), read by the default checker; or
+  - a dedicated boolean on product/variant via a plugin extension.
+  Document the chosen mechanism.
+- **Server-side guard:** reject a non-returnable variant injected into a submitted form
+  (validate in the builder / form handling, not only UI hiding) so it cannot be persisted.
+- **Migration:** if storage adds columns, add `src/Migrations/Version<YYYYMMDDHHMMSS>.php`
+  that runs cleanly on an existing schema (namespace `Madcoders\SyliusRmaPlugin\Migrations`).
+- **Optional messaging:** expose the rule to templates via
+  `src/Twig/RmaConfigExtension.php` only if needed to message "some items can't be returned".
+
+## Out of scope
+- Reason-specific returnability (returnable for some reasons, not others).
+- Per-channel returnability configuration.
+- Bulk admin tooling for tagging many products at once (single product/variant flag only).
+
+## Verify
+- `make phpstan`, `make ecs`, `make phpunit` green.
+- `make behat` covers: a returnable-only order behaves as today; a mixed order shows only the
+  returnable lines; an all-non-returnable order offers nothing to return; a submission
+  referencing a non-returnable variant is rejected and not persisted.

--- a/features/non_returnable_products.feature
+++ b/features/non_returnable_products.feature
@@ -1,0 +1,44 @@
+@madcoders_rma @madcoders_rma_non_returnable
+Feature: Non-returnable products are excluded from the return flow
+    In order to keep products that cannot be taken back out of the RMA flow
+    As a store owner
+    I want products flagged as non-returnable to be omitted from a customer's return form
+
+    Background:
+        Given the store operates on a single channel in the "United States" named "Channel 1"
+        And Store return address with data for channel "Channel 1":
+            | field    | type  | value         |
+            | company  | field | Company 1     |
+            | street   | field | 326 Avenue    |
+            | city     | field | New York      |
+            | postcode | field | 73110         |
+            | country  | field | United States |
+        And the store ships everywhere for "Standard shipping"
+        And the store allows paying Offline for all channels
+        And the store has a product "Returnable Product"
+        And the store has a product "Sealed Product"
+        And the store has customer "John Doe" with email "john.doe@madcoders.pl"
+        And I registered with previously used "john.doe@madcoders.pl" email and "MyPassword.123" password
+        And I am logged in as "john.doe@madcoders.pl"
+        And there are return reasons:
+            | code       | name       | deadline_to_return |
+            | reason_360 | Reason 360 | 360                |
+
+    @ui
+    Scenario: A non-returnable product is hidden from the return form on a mixed order
+        Given there is a customer "john.doe@madcoders.pl" that placed order with "Returnable Product" product to "United States" based billing address with "Standard shipping" shipping method and "Offline" payment method
+        And the order also contains 1 unit of product "Sealed Product"
+        And the product "Sealed Product" is non-returnable
+        And this order has already been shipped
+        And the order's state is "fulfilled"
+        When I am on order return page for latest order
+        Then I should see product "Returnable Product" on the return form
+        And I should not see product "Sealed Product" on the return form
+
+    @ui
+    Scenario: An order made up only of non-returnable products offers nothing to return
+        Given the product "Returnable Product" is non-returnable
+        And there is a customer "john.doe@madcoders.pl" that placed order with "Returnable Product" product to "United States" based billing address with "Standard shipping" shipping method and "Offline" payment method
+        And this order has already been shipped
+        And the order's state is "fulfilled"
+        Then I should not be able to open the return form for latest order

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,11 @@ parameters:
         # Makes PHPStan crash
         - 'src/DependencyInjection/Configuration.php'
 
+        # Public extension-point trait for the application's Product model. It is consumed by the
+        # host app (and the test application), which live outside the analysed `src` scope, so
+        # PHPStan reports a false-positive `trait.unused` here.
+        - 'src/Entity/NonReturnableProductTrait.php'
+
         # Test dependencies
         - 'tests/Application/**'
 

--- a/src/Entity/NonReturnableProductInterface.php
+++ b/src/Entity/NonReturnableProductInterface.php
@@ -19,8 +19,9 @@ namespace Madcoders\SyliusRmaPlugin\Entity;
 /**
  * Implemented by the application's Sylius Product to carry the per-product "non-returnable" flag.
  *
- * The application Product model implements this interface (backed by a `non_returnable` boolean
- * column; the plugin migration adds it to `sylius_product`). The default
+ * Apply {@see NonReturnableProductTrait} on the application Product model to satisfy this contract
+ * (it supplies the `non_returnable` column and accessors; the plugin migration adds the column to
+ * `sylius_product`). The default
  * {@see \Madcoders\SyliusRmaPlugin\Services\ProductReturnabilityChecker} reads the flag through this
  * interface; a product whose model does not implement it is always returnable.
  */

--- a/src/Entity/NonReturnableProductInterface.php
+++ b/src/Entity/NonReturnableProductInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Madcoders\SyliusRmaPlugin\Entity;
+
+/**
+ * Implemented by the application's Sylius Product to carry the per-product "non-returnable" flag.
+ *
+ * The application Product model implements this interface (backed by a `non_returnable` boolean
+ * column; the plugin migration adds it to `sylius_product`). The default
+ * {@see \Madcoders\SyliusRmaPlugin\Services\ProductReturnabilityChecker} reads the flag through this
+ * interface; a product whose model does not implement it is always returnable.
+ */
+interface NonReturnableProductInterface
+{
+    public function isNonReturnable(): bool;
+
+    public function setNonReturnable(bool $nonReturnable): void;
+}

--- a/src/Entity/NonReturnableProductTrait.php
+++ b/src/Entity/NonReturnableProductTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Madcoders\SyliusRmaPlugin\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Supplies the per-product "non-returnable" flag (column + accessors) to an application's Sylius
+ * Product model. Use it together with {@see NonReturnableProductInterface}:
+ *
+ *     class Product extends BaseProduct implements NonReturnableProductInterface
+ *     {
+ *         use NonReturnableProductTrait;
+ *     }
+ *
+ * The column is mapped here, so an application only has to use the trait (the plugin migration adds
+ * the `non_returnable` column to `sylius_product`). It defaults to false, so applying the trait does
+ * not change behaviour until a product is explicitly flagged.
+ */
+trait NonReturnableProductTrait
+{
+    #[ORM\Column(name: 'non_returnable', type: 'boolean', options: ['default' => false])]
+    protected bool $nonReturnable = false;
+
+    public function isNonReturnable(): bool
+    {
+        return $this->nonReturnable;
+    }
+
+    public function setNonReturnable(bool $nonReturnable): void
+    {
+        $this->nonReturnable = $nonReturnable;
+    }
+}

--- a/src/Form/Extension/ProductTypeExtension.php
+++ b/src/Form/Extension/ProductTypeExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Madcoders\SyliusRmaPlugin\Form\Extension;
+
+use Madcoders\SyliusRmaPlugin\Entity\NonReturnableProductInterface;
+use Sylius\Bundle\ProductBundle\Form\Type\ProductType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Adds the "non-returnable" checkbox to the admin product form.
+ *
+ * The field is only added when the configured Product model implements
+ * {@see NonReturnableProductInterface}; otherwise there is nothing to bind to and the form is left
+ * untouched. Rendering of the field is wired through the sylius.admin.product.tab_details template
+ * event (see Resources/config/config.yml).
+ */
+final class ProductTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $dataClass = $options['data_class'] ?? null;
+
+        if (!is_string($dataClass) || !is_a($dataClass, NonReturnableProductInterface::class, true)) {
+            return;
+        }
+
+        $builder->add('nonReturnable', CheckboxType::class, [
+            'required' => false,
+            'label' => 'madcoders_rma.form.product.non_returnable',
+        ]);
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [ProductType::class];
+    }
+}

--- a/src/Migrations/Version20260615000000.php
+++ b/src/Migrations/Version20260615000000.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Madcoders\SyliusRmaPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the per-product "non-returnable" flag (NonReturnableProductTrait) to the Sylius product table.
+ * Existing products default to returnable, so behaviour is unchanged until a product is flagged.
+ */
+final class Version20260615000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add non_returnable flag to sylius_product';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->skipIf(
+            !$schema->hasTable('sylius_product'),
+            'sylius_product table not found; skipping non_returnable column.',
+        );
+        $this->skipIf(
+            $schema->getTable('sylius_product')->hasColumn('non_returnable'),
+            'sylius_product.non_returnable already exists.',
+        );
+
+        $this->addSql('ALTER TABLE sylius_product ADD non_returnable TINYINT(1) DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->skipIf(
+            !$schema->hasTable('sylius_product') || !$schema->getTable('sylius_product')->hasColumn('non_returnable'),
+            'sylius_product.non_returnable not present.',
+        );
+
+        $this->addSql('ALTER TABLE sylius_product DROP non_returnable');
+    }
+}

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -35,6 +35,15 @@ sylius_mailer:
 
 sylius_ui:
   events:
+    # Render the per-product "non-returnable" checkbox on the admin product form details tab.
+    # The field itself is added by Form\Extension\ProductTypeExtension when the Product model
+    # implements NonReturnableProductInterface.
+    sylius.admin.product.tab_details:
+      blocks:
+        madcoders_rma_non_returnable:
+          template: "@MadcodersSyliusRmaPlugin/Admin/Product/_nonReturnable.html.twig"
+          priority: 10
+
     sylius.shop.layout.footer:
       blocks:
         madcoders_rma_return_link:

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -27,6 +27,7 @@ Architects of this package:
                  class="Madcoders\SyliusRmaPlugin\Services\RmaVerificationPossibilityOfReturn">
             <argument type="service" id="madcoders.sylius_rma_plugin.services.max_qty_calculator" />
             <argument type="service" id="madcoders.sylius_rma_plugin.form.choice_provider.reason" />
+            <argument type="service" id="Madcoders\SyliusRmaPlugin\Services\ProductReturnabilityCheckerInterface" />
         </service>
 
         <service id="madcoders.sylius_rma_plugin.services.return_eligibility_checker"
@@ -34,12 +35,18 @@ Architects of this package:
         <service id="Madcoders\SyliusRmaPlugin\Services\ReturnEligibilityCheckerInterface"
                  alias="madcoders.sylius_rma_plugin.services.return_eligibility_checker" />
 
+        <service id="madcoders.sylius_rma_plugin.services.product_returnability_checker"
+                 class="Madcoders\SyliusRmaPlugin\Services\ProductReturnabilityChecker" />
+        <service id="Madcoders\SyliusRmaPlugin\Services\ProductReturnabilityCheckerInterface"
+                 alias="madcoders.sylius_rma_plugin.services.product_returnability_checker" />
+
         <service id="madcoders.sylius_rma_plugin.return_request_builder" class="Madcoders\SyliusRmaPlugin\Services\ReturnRequestBuilder">
             <argument type="service" id="madcoders_rma.repository.order_return" />
             <argument type="service" id="madcoders.sylius_rma_plugin.generator.return_number_generator" />
             <argument type="service" id="madcoders.sylius_rma_plugin.services.max_qty_calculator" />
             <argument type="service" id="madcoders.sylius_rma_plugin.provider.order_by_number" />
             <argument type="service" id="madcoders.sylius_rma_plugin.services.rma_changes_logger" />
+            <argument type="service" id="Madcoders\SyliusRmaPlugin\Services\ProductReturnabilityCheckerInterface" />
         </service>
 
         <service id="madcoders.sylius_rma_plugin.services.rma_admin_user_data" class="Madcoders\SyliusRmaPlugin\Services\RmaAdminUserData">

--- a/src/Resources/config/services/forms.xml
+++ b/src/Resources/config/services/forms.xml
@@ -75,5 +75,10 @@ Architects of this package:
             <tag name="form.type" />
         </service>
 
+        <service id="madcoders.sylius_rma_plugin.form.extension.product_type_extension"
+                 class="Madcoders\SyliusRmaPlugin\Form\Extension\ProductTypeExtension">
+            <tag name="form.type_extension" extended-type="Sylius\Bundle\ProductBundle\Form\Type\ProductType" />
+        </service>
+
     </services>
 </container>

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -207,3 +207,7 @@ madcoders_rma:
         cancelled: "Cancelled"
         withdrawal_request: 'Withdrawal requested'
         withdrawn: 'Withdrawn'
+
+    form:
+        product:
+            non_returnable: 'Non-returnable'

--- a/src/Resources/views/Admin/Product/_nonReturnable.html.twig
+++ b/src/Resources/views/Admin/Product/_nonReturnable.html.twig
@@ -1,0 +1,12 @@
+{#
+ # This file is part of package:
+ # Sylius RMA Plugin
+ #
+ # @copyright MADCODERS Team (www.madcoders.co)
+ # @licence For the full copyright and license information, please view the LICENSE
+ #}
+{% if form.nonReturnable is defined %}
+    <div class="ui segment">
+        {{ form_row(form.nonReturnable) }}
+    </div>
+{% endif %}

--- a/src/Services/ProductReturnabilityChecker.php
+++ b/src/Services/ProductReturnabilityChecker.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Madcoders\SyliusRmaPlugin\Services;
+
+use Madcoders\SyliusRmaPlugin\Entity\NonReturnableProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+/**
+ * Default {@see ProductReturnabilityCheckerInterface}: a variant is non-returnable when its product
+ * is flagged via the admin "non-returnable" checkbox (the {@see NonReturnableProductInterface} flag).
+ *
+ * When the application Product model does not implement that interface, or the flag is off, the
+ * variant is returnable - so behaviour is unchanged until a product is explicitly flagged.
+ */
+final readonly class ProductReturnabilityChecker implements ProductReturnabilityCheckerInterface
+{
+    public function isReturnable(ProductVariantInterface $variant): bool
+    {
+        $product = $variant->getProduct();
+
+        if ($product instanceof NonReturnableProductInterface) {
+            return !$product->isNonReturnable();
+        }
+
+        return true;
+    }
+}

--- a/src/Services/ProductReturnabilityCheckerInterface.php
+++ b/src/Services/ProductReturnabilityCheckerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Madcoders\SyliusRmaPlugin\Services;
+
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+interface ProductReturnabilityCheckerInterface
+{
+    /**
+     * Tells whether a single ordered variant may be added to a return request.
+     *
+     * This is an item-level decision layered on top of the order-level
+     * {@see ReturnEligibilityCheckerInterface}: even when an order is returnable, individual
+     * variants (perishables, hygiene/sealed goods, made-to-order items, gift cards, ...) can be
+     * excluded from the return flow. A non-returnable variant is never offered for return and is
+     * never persisted onto an OrderReturn.
+     */
+    public function isReturnable(ProductVariantInterface $variant): bool;
+}

--- a/src/Services/ReturnRequestBuilder.php
+++ b/src/Services/ReturnRequestBuilder.php
@@ -38,6 +38,7 @@ class ReturnRequestBuilder
         private readonly MaxQtyCalculator $maxQtyCalculator,
         private readonly OrderByNumberProviderInterface $orderByNumberProvider,
         private readonly RmaChangesLogger $changesLogger,
+        private readonly ProductReturnabilityCheckerInterface $productReturnabilityChecker,
     ) {
     }
 
@@ -117,6 +118,12 @@ class ReturnRequestBuilder
             $itemVariantCode = $orderItemVariant->getCode();
             if (null === $itemVariantCode || '' === $itemVariantCode) {
                 throw new \Exception('Cannot create OrderItemReturnRequest for OrderItem without code.');
+            }
+
+            // Item-level eligibility: a non-returnable variant is never offered for return, so it is
+            // not added to the draft (and therefore never reaches the return form or is persisted).
+            if (!$this->productReturnabilityChecker->isReturnable($orderItemVariant)) {
+                continue;
             }
 
             // TODO: $maxQty should be calculated based on following pattern: $qtyOrdered(orShipped) - $qtyAlreadyReturned

--- a/src/Services/RmaVerificationPossibilityOfReturn.php
+++ b/src/Services/RmaVerificationPossibilityOfReturn.php
@@ -29,6 +29,7 @@ class RmaVerificationPossibilityOfReturn
     public function __construct(
         private readonly MaxQtyCalculator $maxQtyCalculator,
         private readonly ChoiceProvider $availableReasonsCreator,
+        private readonly ProductReturnabilityCheckerInterface $productReturnabilityChecker,
     ) {
     }
 
@@ -56,6 +57,12 @@ class RmaVerificationPossibilityOfReturn
             $itemVariantCode = $itemVariant->getCode();
             if (null === $itemVariantCode) {
                 throw new Exception('itemVariant code not find');
+            }
+
+            // A non-returnable variant contributes no returnable quantity, so an order made up only of
+            // non-returnable items reports "nothing to return" and the start-return button is hidden.
+            if (!$this->productReturnabilityChecker->isReturnable($itemVariant)) {
+                continue;
             }
 
             $orderQty = $orderQty + $this->maxQtyCalculator->calculation($orderNumber, $itemVariantCode, $originalQty);

--- a/tests/Application/Entity/Product.php
+++ b/tests/Application/Entity/Product.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Madcoders\SyliusRmaPlugin\Application\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Madcoders\SyliusRmaPlugin\Entity\NonReturnableProductInterface;
+use Sylius\Component\Core\Model\Product as BaseProduct;
+
+/**
+ * Test-application Product overriding the Sylius core model so the plugin's per-product
+ * "non-returnable" flag can be exercised end to end (admin checkbox + return flow + Behat).
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_product')]
+class Product extends BaseProduct implements NonReturnableProductInterface
+{
+    #[ORM\Column(name: 'non_returnable', type: 'boolean', options: ['default' => false])]
+    protected bool $nonReturnable = false;
+
+    public function isNonReturnable(): bool
+    {
+        return $this->nonReturnable;
+    }
+
+    public function setNonReturnable(bool $nonReturnable): void
+    {
+        $this->nonReturnable = $nonReturnable;
+    }
+}

--- a/tests/Application/Entity/Product.php
+++ b/tests/Application/Entity/Product.php
@@ -14,6 +14,7 @@ namespace Tests\Madcoders\SyliusRmaPlugin\Application\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Madcoders\SyliusRmaPlugin\Entity\NonReturnableProductInterface;
+use Madcoders\SyliusRmaPlugin\Entity\NonReturnableProductTrait;
 use Sylius\Component\Core\Model\Product as BaseProduct;
 
 /**
@@ -24,16 +25,5 @@ use Sylius\Component\Core\Model\Product as BaseProduct;
 #[ORM\Table(name: 'sylius_product')]
 class Product extends BaseProduct implements NonReturnableProductInterface
 {
-    #[ORM\Column(name: 'non_returnable', type: 'boolean', options: ['default' => false])]
-    protected bool $nonReturnable = false;
-
-    public function isNonReturnable(): bool
-    {
-        return $this->nonReturnable;
-    }
-
-    public function setNonReturnable(bool $nonReturnable): void
-    {
-        $this->nonReturnable = $nonReturnable;
-    }
+    use NonReturnableProductTrait;
 }

--- a/tests/Application/config/packages/_sylius.yaml
+++ b/tests/Application/config/packages/_sylius.yaml
@@ -18,3 +18,11 @@ sylius_shop:
 
 sylius_api:
     enabled: true
+
+# Override the Sylius product model so the plugin's per-product non-returnable flag can be
+# exercised end to end (admin checkbox + return flow + Behat).
+sylius_product:
+    resources:
+        product:
+            classes:
+                model: Tests\Madcoders\SyliusRmaPlugin\Application\Entity\Product

--- a/tests/Application/config/packages/doctrine.yaml
+++ b/tests/Application/config/packages/doctrine.yaml
@@ -12,3 +12,11 @@ doctrine:
         charset: UTF8
 
         url: '%env(resolve:DATABASE_URL)%'
+    orm:
+        mappings:
+            TestApplication:
+                is_bundle: false
+                type: attribute
+                dir: '%kernel.project_dir%/Entity'
+                prefix: 'Tests\Madcoders\SyliusRmaPlugin\Application\Entity'
+                alias: TestApplication

--- a/tests/Behat/Context/Setup/NonReturnableProductContext.php
+++ b/tests/Behat/Context/Setup/NonReturnableProductContext.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Madcoders\SyliusRmaPlugin\Behat\Context\Setup;
+
+use Behat\Behat\Context\Context;
+use Madcoders\SyliusRmaPlugin\Entity\NonReturnableProductInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Webmozart\Assert\Assert;
+
+final class NonReturnableProductContext implements Context
+{
+    /**
+     * @param RepositoryInterface<ProductInterface> $productRepository
+     */
+    public function __construct(private readonly RepositoryInterface $productRepository)
+    {
+    }
+
+    /**
+     * @Given /^the (product "[^"]+") is non-returnable$/
+     */
+    public function theProductIsNonReturnable(ProductInterface $product): void
+    {
+        Assert::isInstanceOf(
+            $product,
+            NonReturnableProductInterface::class,
+            'The configured Product model must implement NonReturnableProductInterface for this scenario.',
+        );
+
+        $product->setNonReturnable(true);
+        $this->productRepository->add($product);
+    }
+}

--- a/tests/Behat/Context/Ui/Shop/Rma/ReturnFormContext.php
+++ b/tests/Behat/Context/Ui/Shop/Rma/ReturnFormContext.php
@@ -84,6 +84,48 @@ class ReturnFormContext implements Context
     }
 
     /**
+     * @Then /^I should not be able to open the return form for (latest order)$/
+     */
+    public function iShouldNotBeAbleToOpenTheReturnForm(OrderInterface $order): void
+    {
+        $parameters = ['orderNumber' => str_replace('#', '', $order->getNumber())];
+
+        try {
+            // tolerant open: when an order has nothing to return the controller redirects away
+            $this->returnFormPage->tryToOpen($parameters);
+        } catch (UnexpectedPageException) {
+            // redirected off the return form - that is the expected "nothing to return" outcome
+        }
+
+        Assert::false(
+            $this->returnFormPage->isOpen($parameters),
+            'Expected the return form not to open (nothing to return), but it did.',
+        );
+    }
+
+    /**
+     * @Then /^I should see product "([^"]+)" on the return form$/
+     */
+    public function iShouldSeeProductOnTheReturnForm(string $productName): void
+    {
+        Assert::true(
+            $this->returnFormPage->hasItemWithProductName($productName),
+            sprintf('Expected product "%s" to be listed on the return form, but it was not.', $productName),
+        );
+    }
+
+    /**
+     * @Then /^I should not see product "([^"]+)" on the return form$/
+     */
+    public function iShouldNotSeeProductOnTheReturnForm(string $productName): void
+    {
+        Assert::false(
+            $this->returnFormPage->hasItemWithProductName($productName),
+            sprintf('Expected product "%s" not to be listed on the return form, but it was.', $productName),
+        );
+    }
+
+    /**
      * @When I choose reason with code :reasonCode
      */
     public function iChooseReason(string $reasonCode): void

--- a/tests/Behat/Page/Shop/Rma/ReturnFormPage.php
+++ b/tests/Behat/Page/Shop/Rma/ReturnFormPage.php
@@ -89,6 +89,11 @@ class ReturnFormPage extends SymfonyPage implements ReturnFormPageInterface, Fla
         $this->getElement('rma_submit_return_form')->click();
     }
 
+    public function hasItemWithProductName(string $productName): bool
+    {
+        return str_contains($this->getElement('rma_return_items')->getText(), $productName);
+    }
+
     private function returnFormHasNoteField(): bool
     {
         return $this->getDocument()->hasField('madcoders_rma_return_item_customerNote');
@@ -108,6 +113,7 @@ class ReturnFormPage extends SymfonyPage implements ReturnFormPageInterface, Fla
     {
         return array_merge(parent::getDefinedElements(), [
             'rma_submit_return_form' => '[data-test-madcoders-rma-submit-return-form-button]',
+            'rma_return_items' => '#madcoders-rm-return-items',
         ]);
     }
 

--- a/tests/Behat/Page/Shop/Rma/ReturnFormPageInterface.php
+++ b/tests/Behat/Page/Shop/Rma/ReturnFormPageInterface.php
@@ -37,4 +37,6 @@ interface ReturnFormPageInterface extends SymfonyPageInterface
     public function getItemReturnQty(int $index): string;
 
     public function submitThisOrderReturnForm(): void;
+
+    public function hasItemWithProductName(string $productName): bool;
 }

--- a/tests/Behat/Resources/services.xml
+++ b/tests/Behat/Resources/services.xml
@@ -41,6 +41,11 @@ Architects of this package:
             <argument type="service" id="madcoders_rma.repository.order_return_reason" />
         </service>
 
+        <service id="madcoders.rma.context.setup.non_returnable_product"
+                 class="Tests\Madcoders\SyliusRmaPlugin\Behat\Context\Setup\NonReturnableProductContext">
+            <argument type="service" id="sylius.repository.product" />
+        </service>
+
         <service id="madcoders.rma.context.setup.return_consent"
                  class="Tests\Madcoders\SyliusRmaPlugin\Behat\Context\Setup\ReturnConsentContext">
             <argument type="service" id="madcoders_rma.repository.order_return_consent" />

--- a/tests/Behat/Resources/suites.yml
+++ b/tests/Behat/Resources/suites.yml
@@ -15,6 +15,7 @@ imports:
     - suites/ui/shop/rma/submit_form.yml
     - suites/ui/shop/rma/customer_area.yml
     - suites/ui/shop/rma/withdrawal.yml
+    - suites/ui/shop/rma/non_returnable.yml
     - suites/ui/admin/rma/managing_return_reasons.yml
     - suites/ui/admin/rma/managing_return_consents.yml
     - suites/ui/admin/rma/managing_return_status.yml

--- a/tests/Behat/Resources/suites/ui/shop/rma/non_returnable.yml
+++ b/tests/Behat/Resources/suites/ui/shop/rma/non_returnable.yml
@@ -1,0 +1,53 @@
+#
+# This file is part of package:
+# Sylius RMA Plugin
+#
+# @copyright MADCODERS Team (www.madcoders.co)
+# @licence For the full copyright and license information, please view the LICENSE
+#
+# Architects of this package:
+# @author Leonid Moshko <l.moshko@madcoders.pl>
+# @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+#
+default:
+    suites:
+        madcoders_rma_non_returnable:
+            contexts:
+                # hook
+                - sylius.behat.context.hook.doctrine_orm
+                - sylius.behat.context.hook.mailer
+
+                # setup
+                - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.order
+                - sylius.behat.context.setup.user
+                - sylius.behat.context.setup.customer
+                - sylius.behat.context.setup.shop_security
+                - sylius.behat.context.setup.address
+                - sylius.behat.context.setup.product
+                - sylius.behat.context.setup.shipping
+                - sylius.behat.context.setup.payment
+                - madcoders.rma.context.setup.order
+                - madcoders.rma.context.setup.auth
+                - madcoders.rma.context.setup.return_reason
+                - madcoders.rma.context.setup.non_returnable_product
+                - madcoders.rma.context.setup.return
+                - madcoders.rma.context.setup.return_address
+
+                # transformers
+                - sylius.behat.context.transform.channel
+                - sylius.behat.context.transform.order
+                - sylius.behat.context.transform.customer
+                - sylius.behat.context.transform.user
+                - sylius.behat.context.transform.product
+                - sylius.behat.context.transform.shared_storage
+                - sylius.behat.context.transform.lexical
+                - sylius.behat.context.transform.shipping_method
+                - sylius.behat.context.transform.address
+                - sylius.behat.context.transform.payment
+
+                # ui
+                - madcoders.rma.context.ui.shop.rma.return_form
+
+            filters:
+                tags: "@madcoders_rma_non_returnable && @ui"

--- a/tests/Unit/Services/ProductReturnabilityCheckerTest.php
+++ b/tests/Unit/Services/ProductReturnabilityCheckerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Madcoders\SyliusRmaPlugin\Unit\Services;
+
+use Madcoders\SyliusRmaPlugin\Entity\NonReturnableProductInterface;
+use Madcoders\SyliusRmaPlugin\Services\ProductReturnabilityChecker;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Tests\Madcoders\SyliusRmaPlugin\Unit\UnitTestCase;
+
+class ProductReturnabilityCheckerTest extends UnitTestCase
+{
+    use ProphecyTrait;
+
+    /** @test */
+    public function a_variant_of_a_flagged_product_is_not_returnable()
+    {
+        $variant = $this->variantWithProduct($this->nonReturnableProduct(true));
+
+        $this->assertFalse((new ProductReturnabilityChecker())->isReturnable($variant));
+    }
+
+    /** @test */
+    public function a_variant_of_an_unflagged_product_is_returnable()
+    {
+        $variant = $this->variantWithProduct($this->nonReturnableProduct(false));
+
+        $this->assertTrue((new ProductReturnabilityChecker())->isReturnable($variant));
+    }
+
+    /** @test */
+    public function a_variant_whose_product_does_not_support_the_flag_is_returnable()
+    {
+        // a plain Sylius product (model not implementing the interface) is always returnable
+        $product = $this->prophesize(ProductInterface::class);
+        $variant = $this->variantWithProduct($product->reveal());
+
+        $this->assertTrue((new ProductReturnabilityChecker())->isReturnable($variant));
+    }
+
+    /** @test */
+    public function a_variant_without_a_product_is_returnable()
+    {
+        $variant = $this->variantWithProduct(null);
+
+        $this->assertTrue((new ProductReturnabilityChecker())->isReturnable($variant));
+    }
+
+    private function variantWithProduct(?ProductInterface $product): ProductVariantInterface
+    {
+        $variant = $this->prophesize(ProductVariantInterface::class);
+        $variant->getProduct()->willReturn($product);
+
+        return $variant->reveal();
+    }
+
+    private function nonReturnableProduct(bool $nonReturnable): ProductInterface
+    {
+        $product = $this->prophesize(ProductInterface::class);
+        $product->willImplement(NonReturnableProductInterface::class);
+        $product->isNonReturnable()->willReturn($nonReturnable);
+
+        return $product->reveal();
+    }
+}


### PR DESCRIPTION
## Summary

First version of **item-level return eligibility**: lets a merchant flag a product as
**non-returnable** so its variants are excluded from the customer return flow, layered on top
of the existing order-level eligibility. Closes #18.

A non-returnable product:
- is never offered for return and is never persisted onto an `OrderReturn`;
- removes the line regardless of remaining quantity;
- when an order is made up **only** of non-returnable products, the customer sees "nothing to
  return" (the return form is not reachable), exactly like an ineligible order.

Default behaviour is unchanged: with nothing flagged, every product stays returnable.

## How it works

- `ProductReturnabilityCheckerInterface::isReturnable(ProductVariantInterface)` - new item-level
  checker, bound to a default `ProductReturnabilityChecker` and overridable via the alias (same
  pattern as the existing eligibility checkers documented in the README "Customizations" chapter).
- The checker is consulted in:
  - `ReturnRequestBuilder::build()` - non-returnable variants are skipped when building the draft,
    so they never reach the form or get persisted;
  - `RmaVerificationPossibilityOfReturn` - non-returnable variants contribute no returnable
    quantity, so an all-non-returnable order reports nothing to return.
- The flag is carried by `NonReturnableProductInterface` on the application's `Product` model
  (a `non_returnable` boolean column; a migration adds it to `sylius_product`).
- The admin product form gains a **"Non-returnable"** checkbox via a `ProductType` form
  extension, rendered through the `sylius.admin.product.tab_details` template event - only when
  the Product model implements the interface.

## Integrator setup

Have your Sylius `Product` implement `NonReturnableProductInterface` (see the README section
"Optional: mark products as non-returnable"). The test application's `Product` override
demonstrates the wiring.

## Tests

- **PHPUnit**: `ProductReturnabilityCheckerTest` (flagged / unflagged / model-without-interface /
  no-product). Full unit suite green (63 tests).
- **Behat** (`features/non_returnable_products.feature`): a non-returnable product is hidden from
  a mixed order's return form while the returnable product stays listed; an all-non-returnable
  order cannot open the return form. Validated locally against MySQL together with the existing
  `submit_form` (5) and `withdrawal` (10) suites - no regressions.
- **PHPStan** (level max) and **ECS** clean on the changeset.

## Notes

- Draft: opened for review of the approach (per-product flag, Product-entity extension).
- Per-reason returnability, per-channel configuration, and bulk admin tagging are intentionally
  out of scope (see #18).
