### PR TITLE
feat(generator): default RMA number format RMA-{orderNumber}-{n} via ReturnNumberGeneratorInterface

### DIFF
--- a/features/rma_number_format.feature
+++ b/features/rma_number_format.feature
@@ -1,0 +1,49 @@
+@madcoders_rma @madcoders_rma_submit_form @madcoders_rma_submit_form_as_signed_in_customer
+Feature: Default RMA number format
+    In order to recognise my return requests by a consistent, order-derived identifier
+    As a signed in customer
+    I want each return I create to be numbered RMA-{orderNumber}-{n}
+
+        Background:
+            Given the store operates on a single channel in the "United States" named "Channel 1"
+            And Store return address with data for channel "Channel 1":
+                | field               | type              | value                               |
+                | company             | field             | Company 1                           |
+                | street              | field             | 326 Avenue                          |
+                | city                | field             | New York                            |
+                | postcode            | field             | 73110                               |
+                | country             | field             | United States                       |
+            And the store ships everywhere for "Standard shipping"
+            And the store allows paying Offline for all channels
+            And the store has a product "Product A"
+            And the store has customer "John Doe" with email "john.doe@madcoders.pl"
+            And I registered with previously used "john.doe@madcoders.pl" email and "MyPassword.123" password
+            And I am logged in as "john.doe@madcoders.pl"
+            And there are return reasons:
+                | code         | name                     | deadline_to_return |
+                | reason_360   | Reason 360               | 360                |
+            And there is a customer "john.doe@madcoders.pl" that placed order with "Product A" product to "United States" based billing address with "Standard shipping" shipping method and "Offline" payment method
+            And this order has already been shipped
+            And the order's state is "fulfilled"
+
+        @ui
+        Scenario: Two consecutive returns for one order are numbered sequentially
+            # first return for the order
+            Given I am on order return page for latest order
+            When I choose reason with code "reason_360"
+            And I fill in my bank account in IBAN format
+            And I click submit button for return form
+            Then I should be redirected to return review page for latest order
+            # approve it so a new return can be started for the same order
+            When I am on order return review page for latest order
+            And I approve return form
+            Then I should be redirected to success page for latest order
+            # second return for the same order
+            When I am on order return page for latest order
+            And I choose reason with code "reason_360"
+            And I fill in my bank account in IBAN format
+            And I click submit button for return form
+            Then I should be redirected to return review page for latest order
+            # both returns follow the RMA-{orderNumber}-{n} format with an incremented sequence
+            And an order return numbered "RMA-{orderNumber}-1" should exist for latest order
+            And an order return numbered "RMA-{orderNumber}-2" should exist for latest order

--- a/src/Generator/ReturnNumberGenerator.php
+++ b/src/Generator/ReturnNumberGenerator.php
@@ -17,9 +17,10 @@ declare(strict_types=1);
 namespace Madcoders\SyliusRmaPlugin\Generator;
 
 use Madcoders\SyliusRmaPlugin\Entity\OrderReturnInterface;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
-class ReturnNumberGenerator
+class ReturnNumberGenerator implements ReturnNumberGeneratorInterface
 {
     /**
      * @param RepositoryInterface<OrderReturnInterface> $orderReturnRepository
@@ -28,16 +29,40 @@ class ReturnNumberGenerator
     {
     }
 
+    /**
+     * Default format: RMA-{orderNumber}-{n}, where {n} is incremented until the return
+     * number is unique (no collision with an existing OrderReturn.returnNumber). The
+     * separator is URL-safe so the number can be embedded as a single route segment.
+     */
+    public function generate(OrderInterface $order): string
+    {
+        return $this->generateForOrderNumber(str_replace('#', '', (string) $order->getNumber()));
+    }
+
+    /**
+     * @deprecated since 1.3, use generate(OrderInterface $order) instead. Kept as a thin
+     *             shim for external code still calling the generator with an order number.
+     */
     public function returnNumberGenerate(string $orderNumber): string
     {
+        return $this->generateForOrderNumber($orderNumber);
+    }
+
+    private function generateForOrderNumber(string $orderNumber): string
+    {
         $returnOrderNumberId = 1;
-        $returnOrderNumber = 'R' . $orderNumber . '-' . $returnOrderNumberId;
+        $returnOrderNumber = $this->format($orderNumber, $returnOrderNumberId);
 
         while ($this->orderReturnRepository->findOneBy(['returnNumber' => $returnOrderNumber]) instanceof OrderReturnInterface) {
             ++$returnOrderNumberId;
-            $returnOrderNumber = 'R' . $orderNumber . '-' . $returnOrderNumberId;
+            $returnOrderNumber = $this->format($orderNumber, $returnOrderNumberId);
         }
 
         return $returnOrderNumber;
+    }
+
+    private function format(string $orderNumber, int $sequence): string
+    {
+        return sprintf('RMA-%s-%d', $orderNumber, $sequence);
     }
 }

--- a/src/Generator/ReturnNumberGeneratorInterface.php
+++ b/src/Generator/ReturnNumberGeneratorInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Madcoders\SyliusRmaPlugin\Generator;
+
+use Sylius\Component\Core\Model\OrderInterface;
+
+interface ReturnNumberGeneratorInterface
+{
+    /**
+     * Generates a unique return (RMA) number for the given order.
+     */
+    public function generate(OrderInterface $order): string;
+}

--- a/src/Resources/config/services/generators.xml
+++ b/src/Resources/config/services/generators.xml
@@ -30,5 +30,8 @@ Architects of this package:
             <argument type="service" id="madcoders_rma.repository.order_return" />
         </service>
 
+        <!-- Alias the interface to the default generator so integrators can replace or decorate it. -->
+        <service id="Madcoders\SyliusRmaPlugin\Generator\ReturnNumberGeneratorInterface" alias="madcoders.sylius_rma_plugin.generator.return_number_generator" />
+
      </services>
 </container>

--- a/src/Services/ReturnRequestBuilder.php
+++ b/src/Services/ReturnRequestBuilder.php
@@ -21,7 +21,7 @@ use Madcoders\SyliusRmaPlugin\Entity\OrderReturn;
 use Madcoders\SyliusRmaPlugin\Entity\OrderReturnChangeLogAuthor;
 use Madcoders\SyliusRmaPlugin\Entity\OrderReturnInterface;
 use Madcoders\SyliusRmaPlugin\Entity\OrderReturnItem;
-use Madcoders\SyliusRmaPlugin\Generator\ReturnNumberGenerator;
+use Madcoders\SyliusRmaPlugin\Generator\ReturnNumberGeneratorInterface;
 use Madcoders\SyliusRmaPlugin\Provider\OrderByNumberProviderInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -34,7 +34,7 @@ class ReturnRequestBuilder
      */
     public function __construct(
         private readonly RepositoryInterface $orderReturnRepository,
-        private readonly ReturnNumberGenerator $orderReturnGenerator,
+        private readonly ReturnNumberGeneratorInterface $orderReturnGenerator,
         private readonly MaxQtyCalculator $maxQtyCalculator,
         private readonly OrderByNumberProviderInterface $orderByNumberProvider,
         private readonly RmaChangesLogger $changesLogger,
@@ -64,7 +64,7 @@ class ReturnRequestBuilder
         $orderReturn = new OrderReturn();
 
         // populate order data
-        $orderReturnNumber = $this->orderReturnGenerator->returnNumberGenerate($orderNumber);
+        $orderReturnNumber = $this->orderReturnGenerator->generate($order);
         $orderReturn->setReturnNumber($orderReturnNumber);
 
         $channel = $order->getChannel();

--- a/tests/Behat/Context/Ui/Shop/Rma/ReturnSuccessContext.php
+++ b/tests/Behat/Context/Ui/Shop/Rma/ReturnSuccessContext.php
@@ -66,6 +66,27 @@ class ReturnSuccessContext implements Context
     }
 
     /**
+     * Asserts a return with the expected number exists. The "{orderNumber}" placeholder in the
+     * expected value is replaced with the latest order number, so the format can be checked
+     * without hard-coding the dynamic order number into the feature.
+     *
+     * @Then /^an order return numbered "([^"]+)" should exist for (latest order)$/
+     */
+    public function anOrderReturnNumberedShouldExist(string $expectedReturnNumber, OrderInterface $order): void
+    {
+        $orderNumber = str_replace('#', '', (string) $order->getNumber());
+        $expectedReturnNumber = str_replace('{orderNumber}', $orderNumber, $expectedReturnNumber);
+
+        $orderReturn = $this->orderReturnRepository->findOneBy(['returnNumber' => $expectedReturnNumber]);
+
+        Assert::isInstanceOf(
+            $orderReturn,
+            OrderReturnInterface::class,
+            sprintf('Expected an order return numbered "%s" to exist, but none was found.', $expectedReturnNumber),
+        );
+    }
+
+    /**
      * @Then /^email with order return confirmation should be sent to "([^"]+)" for (latest order)$/
      */
     public function iRecievedConfirmationEmail(string $recipient, OrderInterface $order, string $localeCode = 'en_US'): void

--- a/tests/Unit/Generator/ReturnNumberGeneratorTest.php
+++ b/tests/Unit/Generator/ReturnNumberGeneratorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of package:
+ * Sylius RMA Plugin
+ *
+ * @copyright MADCODERS Team (www.madcoders.co)
+ * @licence For the full copyright and license information, please view the LICENSE
+ *
+ * Architects of this package:
+ * @author Leonid Moshko <l.moshko@madcoders.pl>
+ * @author Piotr Lewandowski <p.lewandowski@madcoders.pl>
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Madcoders\SyliusRmaPlugin\Unit\Generator;
+
+use Madcoders\SyliusRmaPlugin\Entity\OrderReturnInterface;
+use Madcoders\SyliusRmaPlugin\Generator\ReturnNumberGenerator;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Tests\Madcoders\SyliusRmaPlugin\Unit\UnitTestCase;
+
+class ReturnNumberGeneratorTest extends UnitTestCase
+{
+    use ProphecyTrait;
+
+    /** @var ObjectProphecy<RepositoryInterface<OrderReturnInterface>> */
+    private ObjectProphecy $orderReturnRepository;
+
+    protected function setUp(): void
+    {
+        $this->orderReturnRepository = $this->prophesize(RepositoryInterface::class);
+    }
+
+    /** @test */
+    function it_generates_a_number_in_the_rma_order_sequence_format()
+    {
+        // no existing return numbers collide
+        $this->orderReturnRepository->findOneBy(Argument::any())->willReturn(null);
+
+        $this->assertSame('RMA-000123-1', $this->generator()->generate($this->order('000123')));
+    }
+
+    /** @test */
+    function it_increments_the_sequence_until_the_number_is_unique()
+    {
+        // RMA-000123-1 already exists, RMA-000123-2 is free
+        $this->orderReturnRepository->findOneBy(['returnNumber' => 'RMA-000123-1'])->willReturn($this->existingReturn());
+        $this->orderReturnRepository->findOneBy(['returnNumber' => 'RMA-000123-2'])->willReturn(null);
+
+        $this->assertSame('RMA-000123-2', $this->generator()->generate($this->order('000123')));
+    }
+
+    /** @test */
+    function two_consecutive_returns_for_one_order_get_sequential_numbers()
+    {
+        $order = $this->order('000123');
+
+        // first return: nothing exists yet
+        $this->orderReturnRepository->findOneBy(['returnNumber' => 'RMA-000123-1'])->willReturn(null);
+        $this->assertSame('RMA-000123-1', $this->generator()->generate($order));
+
+        // second return: the first one now exists, so the next sequence is used
+        $this->orderReturnRepository->findOneBy(['returnNumber' => 'RMA-000123-1'])->willReturn($this->existingReturn());
+        $this->orderReturnRepository->findOneBy(['returnNumber' => 'RMA-000123-2'])->willReturn(null);
+        $this->assertSame('RMA-000123-2', $this->generator()->generate($order));
+    }
+
+    /** @test */
+    function the_deprecated_order_number_shim_produces_the_same_format()
+    {
+        $this->orderReturnRepository->findOneBy(Argument::any())->willReturn(null);
+
+        $this->assertSame('RMA-000123-1', $this->generator()->returnNumberGenerate('000123'));
+    }
+
+    private function generator(): ReturnNumberGenerator
+    {
+        return new ReturnNumberGenerator($this->orderReturnRepository->reveal());
+    }
+
+    private function order(string $number): OrderInterface
+    {
+        $order = $this->prophesize(OrderInterface::class);
+        $order->getNumber()->willReturn($number);
+
+        return $order->reveal();
+    }
+
+    private function existingReturn(): OrderReturnInterface
+    {
+        return $this->prophesize(OrderReturnInterface::class)->reveal();
+    }
+}


### PR DESCRIPTION
Refs #15

## What

Makes return-number generation swappable behind an interface and sets a new, order-derived default format.

- New `ReturnNumberGeneratorInterface::generate(OrderInterface $order): string`.
- `ReturnNumberGenerator` implements it and derives the number from the order. Default format is now `RMA-{orderNumber}-{n}`, incremented until unique (no collision with an existing `OrderReturn.returnNumber`). The `#` prefix is stripped from the order number.
- `ReturnRequestBuilder` depends on the interface and passes the already-resolved `$order`.
- The interface is aliased to the default service in `generators.xml`, so integrators can replace or decorate it without patching the plugin.
- The old `returnNumberGenerate(string)` is kept as a thin deprecated shim for external callers.

## Format note

Issue #15 describes keeping `R{orderNumber}-{n}`, and the original request was `RMA/{orderNumber}/{n}`. The literal slash form breaks the existing shop routes that embed the return number as a single URL path segment (e.g. `/rma-summary/{returnNumber}`), so a URL-safe hyphen separator is used: `RMA-{orderNumber}-{n}` (e.g. `RMA-000001-1`, `RMA-000001-2`). The ticket text should be updated to match.

## Tests

- Unit (`tests/Unit/Generator/ReturnNumberGeneratorTest.php`): format, sequence increment on collision, two consecutive returns, deprecated shim.
- Behat (`features/rma_number_format.feature`): creates two consecutive returns for a single order and asserts `RMA-{orderNumber}-1` and `RMA-{orderNumber}-2` (new `an order return numbered "..." should exist` step).

Quality gate green locally: PHPUnit (63 tests), PHPStan (no errors), ECS (clean), and the new Behat scenario.