### PR TITLE
feat(email): self-contained, branded, localized RMA e-mails

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,25 @@ Note that the default `WithdrawalEligibilityChecker` receives the
 [`allow_unpaid_withdrawal`](#configuration) flag as a constructor argument; a full replacement is
 responsible for honouring that flag itself if it still applies.
 
+### Customize the e-mails
+
+Every RMA e-mail is self-contained: it renders the return (RMA) number, the order number, the
+returned items, a state-appropriate message and - when provided - the refund (bank) details, so the
+customer gets a complete record even when the [return-form PDF](#optional-enable-the-return-form-pdf)
+is off. The copy lives under the `madcoders_rma.email.*` translation keys (English plus pl, de, fr,
+it, es, sv, da).
+
+Each e-mail is wrapped by an overridable **header** and **footer** partial - the integration point
+for your shop's branding. Override them in your application (they receive the `channel` in context):
+
+```
+templates/bundles/MadcodersSyliusRmaPlugin/Email/_header.html.twig
+templates/bundles/MadcodersSyliusRmaPlugin/Email/_footer.html.twig
+```
+
+The shared `_returnSummary.html.twig` partial renders the details block and can be overridden the
+same way.
+
 ## Development
 
 Requires PHP 8.2, Composer, Docker (for the database) and Node/Yarn (for the test

--- a/ai/tasks/15-return-email-content.md
+++ b/ai/tasks/15-return-email-content.md
@@ -1,0 +1,120 @@
+# Task 15 - Self-contained, branded, localized RMA e-mails
+
+**Goal:** Make every customer e-mail a complete record of the return - return (RMA) number, order
+number, related items, a state-appropriate description, and full refund details - wrapped in an
+overridable header/footer for shop branding, in 8 locales. Critical because the return-form PDF is
+**off by default**, so the e-mail must carry the information itself. Status: **planned.**
+Tracking issue: [mad-coders/sylius-rma-plugin#23](https://github.com/mad-coders/sylius-rma-plugin/issues/23).
+
+## Background
+The plugin sends 6 customer e-mails, all defined as minimal `subject` + `body` templates under
+`src/Resources/views/Email/` and wired in `src/Resources/config/config.yml:15-34`:
+- `authcode_generated` - `authCodeGenerated.html.twig`, sender `src/Email/AuthCodeEmailSender.php`
+  (context: `authCode`, `channel`; **no `OrderReturn` exists yet**).
+- `return_generated` - `returnFormGenerated.html.twig`, sender `src/Email/ReturnFormEmailSender.php`
+  (context: `orderReturn`, `channel`, `returnAddress`; PDF conditionally attached at `:56-72`).
+- `withdrawal_{requested,confirmed,fallback,cancelled}` - `withdrawal*.html.twig`, sender
+  `src/Email/WithdrawalEmailSender.php` (context: **only** `orderReturn`, `:56`).
+
+Today the bodies render only a greeting + one info line; none show items, refund details, status, or
+(except withdrawal) the order number. `returnFormGenerated.html.twig` still tells the customer to
+"print attached form" even though `madcoders_rma.return_form_pdf_enabled` defaults to `false`
+(`src/DependencyInjection/MadcodersSyliusRmaExtension.php:40`), so no attachment is present.
+
+All the data needed is already on the `OrderReturn` passed to every return e-mail
+(`src/Entity/OrderReturn.php`): `getReturnNumber()`, `getOrderNumber()`, `getOrderReturnStatus()`,
+`getItems()` (each `OrderReturnItem` has `getProductName()`, `getProductSku()`, `getReturnQty()`),
+`getReturnReason()`, `getBankAccountNumber()`, `getAccountHolderName()`, `getBankName()`. The
+PDF-enabled flag is exposed to templates via the global Twig function
+`madcoders_rma_return_form_pdf_enabled()` (`src/Twig/RmaConfigExtension.php:34`).
+
+## Scope
+Re-render all e-mail bodies from existing context (no new data sources); add overridable header/footer
+and a shared return-summary partial; localize the e-mail copy. Default behaviour stays backward
+compatible (existing greeting/info translation keys and their placeholders are preserved so current
+Behat assertions stay valid).
+
+- Every e-mail (all 6) is wrapped by an overridable header partial (top) and footer partial (bottom).
+- Every **return** e-mail renders RMA number, order number, status, items (name + SKU + qty, filtered
+  to `returnQty > 0`), reason (if set), and **full** refund details (IBAN, account holder, bank name;
+  each shown only when present).
+- `return_generated` branches its "what to do next" text on the PDF flag (print & return the attached
+  form vs "this e-mail is your confirmation").
+- `authcode_generated` adds the order number (`authCode.orderNumber`) alongside the code/link; it
+  cannot show an RMA number or items (no return yet).
+- E-mail copy provided in en, pl, de, fr, it, es, sv, da.
+
+## Implementation outline
+- **Partials** (`src/Resources/views/Email/`):
+  - `_header.html.twig` + `_footer.html.twig` - overridable branding extension points (minimal
+    defaults, guard `{% if channel is defined %}`), overridable at
+    `templates/bundles/MadcodersSyliusRmaPlugin/Email/_header.html.twig` / `_footer.html.twig`.
+  - `_returnSummary.html.twig` - renders RMA#, order#, status label, items table, reason, and refund
+    block from `orderReturn`; optional blocks guarded; email-client-safe inline-styled HTML.
+- **Templates:** rewrite each body as header -> content -> footer. `returnFormGenerated` adds the PDF
+  branch + summary; the 4 withdrawal templates keep their greeting + existing `info` line + summary;
+  `authCodeGenerated` adds the order-number line, no summary.
+- **Channel for header/footer:** `WithdrawalEmailSender` resolves and passes `channel`
+  (`sylius.repository.channel`->`findOneByCode($orderReturn->getChannelCode())`); update its DI def in
+  `src/Resources/config/services/emails.xml:38`. `ReturnFormEmailSender` / `AuthCodeEmailSender` /
+  `config.yml` mailer block unchanged.
+- **Translations:** keep `src/Resources/translations/messages.en.yaml` as source of truth; add
+  `messages.{pl,de,fr,it,es,sv,da}.yaml` for the `madcoders_rma.email.*` subtree - subjects, greetings,
+  new `order_return_form.{info_pdf,info_no_pdf}`, `order_return_auth_email.order_info`, and a
+  `summary.*` group (return_number, order_number, status, items, item, sku, quantity, reason,
+  refund_details, bank_account_number, account_holder_name, bank_name, and `state.*` for
+  draft/new/completed/canceled/withdrawal_request/withdrawn). Repoint/remove the misleading
+  `order_return_form.info`.
+- **Tests:** update `tests/Unit/Email/WithdrawalEmailSenderTest.php` for the new channel dependency and
+  `channel` in the send context; extend Behat (`tests/Behat/Context/Ui/Shop/Rma/ReturnSuccessContext.php`,
+  `WithdrawalContext.php`) to assert the body contains the return number + an item name/SKU, plus a
+  `return_generated` PDF-on/off branch scenario.
+
+## E-mail mockups
+Shared summary block (return e-mails), wrapped by header/footer on every e-mail:
+```
+[ _header.html.twig ]   <- override target (shop branding)
+
+Return number:  RMA-100123-1
+Order number:   100123
+Status:         New
+
+Items
+  Item                      SKU         Qty
+  Awesome Mug               MUG-001      2
+  Cool T-Shirt (M)          TS-M-007     1
+
+Reason: Damaged on arrival
+
+Refund details
+  IBAN:            PL39 1160 0006 1780 0564 6461 8314
+  Account holder:  Jan Kowalski
+  Bank:            Bank Przykladowy / BREXPLPW
+
+[ _footer.html.twig ]   <- override target (shop signature/links)
+```
+- **Verification code:** "This verification code is for order #100123." + code + link. No summary.
+- **Return confirmation (New):** greeting + (PDF on: print & return the attached form / PDF off: keep
+  this e-mail as your confirmation, nothing to print) + summary.
+- **Withdrawal requested:** "request received for order #100123, we'll confirm shortly" + summary.
+- **Withdrawal confirmed:** "withdrawal confirmed, order cancelled; refund to the details below" + summary.
+- **Order withdrawn (unpaid instant):** "order withdrawn; unpaid, nothing further" + summary (refund
+  block usually empty).
+- **Handled as a return (fallback):** "handled through our standard return process" + summary.
+
+## Out of scope
+- Masking bank details (full details shown, per decision) and item prices / refund totals.
+- Translating non-e-mail (UI/admin) strings into the new locales.
+- Changing the withdrawal flow or PDF generation itself.
+- Fixing the pre-existing `return_generated` greeting that renders the return number as `%name%`
+  (kept to avoid breaking the current `ReturnSuccessContext` assertion; optional follow-up).
+
+## Verify
+- `make phpunit` green (`tests/Unit/Email/*`), `make behat` covers: return e-mail body contains the
+  return number + an item name/SKU; PDF-on vs PDF-off instruction branch; withdrawal e-mails carry the
+  summary; auth e-mail shows the order number.
+- Header/footer override: drop `templates/bundles/MadcodersSyliusRmaPlugin/Email/_footer.html.twig` in
+  the test app and confirm the override renders instead of the default.
+- Body preview (Twig render / spooled message): header+footer wrap every e-mail; empty-items and
+  null-refund degrade gracefully; RMA#/order#/items present in every return e-mail.
+- `make phpstan`, `make ecs`, `make rector` green; `bin/console lint:yaml src/Resources/translations`.

--- a/features/submit_return_form_as_signed_in_customer.feature
+++ b/features/submit_return_form_as_signed_in_customer.feature
@@ -41,5 +41,6 @@ Feature: Submitting return form as guest
             And I am on order return review page for latest order
             When I approve return form
             Then email with order return confirmation should be sent to "john.doe@madcoders.pl" for latest order
+            And the order return confirmation email to "john.doe@madcoders.pl" should contain the return summary for latest order
             And I should be redirected to success page for latest order
             And I see single success message containing text "Return form has been created"

--- a/features/submit_return_form_with_additional_information.feature
+++ b/features/submit_return_form_with_additional_information.feature
@@ -68,3 +68,17 @@ Feature: Gating the additional information section behind the feature flag
             And I fill in the bank name as "ACME Bank"
             And I click submit button for return form
             Then I should be redirected to return review page for latest order
+
+        @ui
+        Scenario: The confirmation e-mail carries the items and refund details
+            Given the return form requires additional information
+            And I am on order return page for latest order
+            When I choose reason with code "reason_360"
+            And I fill in my bank account in IBAN format
+            And I fill in the account holder name as "John Doe"
+            And I fill in the bank name as "ACME Bank"
+            And I click submit button for return form
+            Then I should be redirected to return review page for latest order
+            When I approve return form
+            Then email with order return confirmation should be sent to "john.doe@madcoders.pl" for latest order
+            And the order return confirmation email to "john.doe@madcoders.pl" should list item "Product A" and refund details "John Doe" and "ACME Bank"

--- a/features/withdrawal_as_signed_in_customer.feature
+++ b/features/withdrawal_as_signed_in_customer.feature
@@ -31,6 +31,7 @@ Feature: Withdraw from an order before it ships
         And latest order should not be cancelled
         And order return for latest order should have a "withdrawal_requested" change-log entry authored by a customer
         And a withdrawal "requested" email should be sent to "john.doe@madcoders.pl" for latest order
+        And the withdrawal email to "john.doe@madcoders.pl" should contain the return summary with item "Product A" for latest order
 
     @ui
     Scenario: A partial withdrawal records only the chosen quantity

--- a/src/Email/WithdrawalEmailSender.php
+++ b/src/Email/WithdrawalEmailSender.php
@@ -17,12 +17,14 @@ declare(strict_types=1);
 namespace Madcoders\SyliusRmaPlugin\Email;
 
 use Madcoders\SyliusRmaPlugin\Entity\OrderReturnInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 
 final readonly class WithdrawalEmailSender implements WithdrawalEmailSenderInterface
 {
     public function __construct(
         private SenderInterface $emailSender,
+        private ChannelRepositoryInterface $channelRepository,
     ) {
     }
 
@@ -53,6 +55,11 @@ final readonly class WithdrawalEmailSender implements WithdrawalEmailSenderInter
             return;
         }
 
-        $this->emailSender->send($email, [$customerEmail], ['orderReturn' => $orderReturn]);
+        $channel = $this->channelRepository->findOneByCode($orderReturn->getChannelCode());
+
+        $this->emailSender->send($email, [$customerEmail], [
+            'orderReturn' => $orderReturn,
+            'channel' => $channel,
+        ]);
     }
 }

--- a/src/Resources/config/services/emails.xml
+++ b/src/Resources/config/services/emails.xml
@@ -37,6 +37,7 @@ Architects of this package:
 
         <service id="madcoders.sylius_rma_plugin.email.withdrawal_email_sender" class="Madcoders\SyliusRmaPlugin\Email\WithdrawalEmailSender">
             <argument type="service" id="sylius.email_sender" />
+            <argument type="service" id="sylius.repository.channel" />
         </service>
         <service id="Madcoders\SyliusRmaPlugin\Email\WithdrawalEmailSenderInterface" alias="madcoders.sylius_rma_plugin.email.withdrawal_email_sender" />
 

--- a/src/Resources/translations/messages.da.yaml
+++ b/src/Resources/translations/messages.da.yaml
@@ -1,0 +1,54 @@
+madcoders_rma:
+    email:
+        order_return_form:
+            subject: 'Returnering af ordre #%returnNumber%'
+            greeting: 'Hej %name%'
+            info_pdf: 'Din returanmodning er registreret. Print den vedhæftede returformular, og send den tilbage sammen med din pakke.'
+            info_no_pdf: 'Din returanmodning er registreret. Gem denne e-mail som din returbekræftelse - der er intet at printe eller sende. Vi kontakter dig med de næste skridt.'
+
+        order_return_auth_email:
+            subject: 'Bekræftelseskode til returnering'
+            order_info: 'Denne bekræftelseskode vedrører ordre %orderNumber%.'
+            auth_code_info: 'for at fortsætte returprocessen skal du indtaste koden %auth_code% på'
+            verification_page: 'bekræftelsessiden'
+
+        summary:
+            return_number: 'Returnummer'
+            order_number: 'Ordrenummer'
+            status: 'Status'
+            items: 'Varer'
+            item: 'Vare'
+            sku: 'SKU'
+            quantity: 'Antal'
+            reason: 'Årsag'
+            refund_details: 'Oplysninger til tilbagebetaling'
+            bank_account_number: 'IBAN'
+            account_holder_name: 'Kontohaver'
+            bank_name: 'Bank'
+            state:
+                draft: 'Kladde'
+                new: 'Ny'
+                completed: 'Afsluttet'
+                canceled: 'Annulleret'
+                withdrawal_request: 'Fortrydelse anmodet'
+                withdrawn: 'Fortrudt'
+
+        withdrawal_requested:
+            subject: 'Anmodning om fortrydelse modtaget #%returnNumber%'
+            greeting: 'Hej'
+            info: 'Vi har modtaget din anmodning om at fortryde ordre %orderNumber%. Vores team gennemgår den og bekræfter fortrydelsen snarest.'
+
+        withdrawal_confirmed:
+            subject: 'Fortrydelse af ordre bekræftet #%returnNumber%'
+            greeting: 'Hej'
+            info: 'Din fortrydelse af ordre %orderNumber% er blevet bekræftet, og ordren er blevet annulleret.'
+
+        withdrawal_fallback:
+            subject: 'Din fortrydelse behandles som en returnering #%returnNumber%'
+            greeting: 'Hej'
+            info: 'Din anmodning om fortrydelse af ordre %orderNumber% behandles via vores almindelige returproces. Vi kontakter dig med de næste skridt.'
+
+        withdrawal_cancelled:
+            subject: 'Ordre fortrudt #%returnNumber%'
+            greeting: 'Hej'
+            info: 'Din ordre %orderNumber% er blevet fortrudt. Da den ikke var betalt, er der ikke mere at gøre.'

--- a/src/Resources/translations/messages.de.yaml
+++ b/src/Resources/translations/messages.de.yaml
@@ -1,0 +1,54 @@
+madcoders_rma:
+    email:
+        order_return_form:
+            subject: 'Rücksendung der Bestellung #%returnNumber%'
+            greeting: 'Hallo %name%'
+            info_pdf: 'Deine Rücksendeanfrage wurde registriert. Bitte drucke das beigefügte Rücksendeformular aus und lege es deinem Paket bei.'
+            info_no_pdf: 'Deine Rücksendeanfrage wurde registriert. Bitte bewahre diese E-Mail als Rücksendebestätigung auf - es muss nichts gedruckt oder versendet werden. Wir melden uns mit den nächsten Schritten.'
+
+        order_return_auth_email:
+            subject: 'Bestätigungscode für die Rücksendung'
+            order_info: 'Dieser Bestätigungscode gilt für die Bestellung %orderNumber%.'
+            auth_code_info: 'um den Rücksendevorgang fortzusetzen, gib bitte den Code %auth_code% ein auf'
+            verification_page: 'der Bestätigungsseite'
+
+        summary:
+            return_number: 'Rücksendenummer'
+            order_number: 'Bestellnummer'
+            status: 'Status'
+            items: 'Artikel'
+            item: 'Artikel'
+            sku: 'SKU'
+            quantity: 'Menge'
+            reason: 'Grund'
+            refund_details: 'Erstattungsdaten'
+            bank_account_number: 'IBAN'
+            account_holder_name: 'Kontoinhaber'
+            bank_name: 'Bank'
+            state:
+                draft: 'Entwurf'
+                new: 'Neu'
+                completed: 'Abgeschlossen'
+                canceled: 'Storniert'
+                withdrawal_request: 'Widerruf angefragt'
+                withdrawn: 'Widerrufen'
+
+        withdrawal_requested:
+            subject: 'Widerrufsanfrage erhalten #%returnNumber%'
+            greeting: 'Hallo'
+            info: 'Wir haben deine Anfrage zum Widerruf der Bestellung %orderNumber% erhalten. Unser Team prüft sie und bestätigt den Widerruf in Kürze.'
+
+        withdrawal_confirmed:
+            subject: 'Widerruf der Bestellung bestätigt #%returnNumber%'
+            greeting: 'Hallo'
+            info: 'Dein Widerruf der Bestellung %orderNumber% wurde bestätigt und die Bestellung wurde storniert.'
+
+        withdrawal_fallback:
+            subject: 'Dein Widerruf wird als Rücksendung bearbeitet #%returnNumber%'
+            greeting: 'Hallo'
+            info: 'Deine Widerrufsanfrage für die Bestellung %orderNumber% wird über unseren regulären Rücksendeprozess bearbeitet. Wir melden uns mit den nächsten Schritten.'
+
+        withdrawal_cancelled:
+            subject: 'Bestellung widerrufen #%returnNumber%'
+            greeting: 'Hallo'
+            info: 'Deine Bestellung %orderNumber% wurde widerrufen. Da sie nicht bezahlt wurde, ist nichts weiter zu tun.'

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -179,12 +179,35 @@ madcoders_rma:
         order_return_form:
             subject: 'Order return #%returnNumber%'
             greeting: 'Hi %name%'
-            info: 'Please print attached form and send to us'
+            info_pdf: 'Your return request has been registered. Please print the attached return form and send it back with your parcel.'
+            info_no_pdf: 'Your return request has been registered. Please keep this e-mail as your return confirmation - there is nothing to print or send. We will contact you with the next steps.'
 
         order_return_auth_email:
             subject: 'Order return verification code'
+            order_info: 'This verification code is for order %orderNumber%.'
             auth_code_info: 'to continue return process please enter %auth_code% code on'
             verification_page: 'verification page'
+
+        summary:
+            return_number: 'Return number'
+            order_number: 'Order number'
+            status: 'Status'
+            items: 'Items'
+            item: 'Item'
+            sku: 'SKU'
+            quantity: 'Quantity'
+            reason: 'Reason'
+            refund_details: 'Refund details'
+            bank_account_number: 'IBAN'
+            account_holder_name: 'Account holder'
+            bank_name: 'Bank'
+            state:
+                draft: 'Draft'
+                new: 'New'
+                completed: 'Completed'
+                canceled: 'Cancelled'
+                withdrawal_request: 'Withdrawal requested'
+                withdrawn: 'Withdrawn'
 
         withdrawal_requested:
             subject: 'Withdrawal request received #%returnNumber%'

--- a/src/Resources/translations/messages.es.yaml
+++ b/src/Resources/translations/messages.es.yaml
@@ -1,0 +1,54 @@
+madcoders_rma:
+    email:
+        order_return_form:
+            subject: 'Devolución del pedido #%returnNumber%'
+            greeting: 'Hola %name%'
+            info_pdf: 'Tu solicitud de devolución ha sido registrada. Imprime el formulario de devolución adjunto y envíalo junto con tu paquete.'
+            info_no_pdf: 'Tu solicitud de devolución ha sido registrada. Conserva este correo como confirmación de la devolución - no hay nada que imprimir ni enviar. Nos pondremos en contacto contigo con los siguientes pasos.'
+
+        order_return_auth_email:
+            subject: 'Código de verificación de la devolución'
+            order_info: 'Este código de verificación corresponde al pedido %orderNumber%.'
+            auth_code_info: 'para continuar con el proceso de devolución, introduce el código %auth_code% en'
+            verification_page: 'la página de verificación'
+
+        summary:
+            return_number: 'Número de devolución'
+            order_number: 'Número de pedido'
+            status: 'Estado'
+            items: 'Artículos'
+            item: 'Artículo'
+            sku: 'SKU'
+            quantity: 'Cantidad'
+            reason: 'Motivo'
+            refund_details: 'Datos para el reembolso'
+            bank_account_number: 'IBAN'
+            account_holder_name: 'Titular de la cuenta'
+            bank_name: 'Banco'
+            state:
+                draft: 'Borrador'
+                new: 'Nuevo'
+                completed: 'Completado'
+                canceled: 'Cancelado'
+                withdrawal_request: 'Desistimiento solicitado'
+                withdrawn: 'Desistido'
+
+        withdrawal_requested:
+            subject: 'Solicitud de desistimiento recibida #%returnNumber%'
+            greeting: 'Hola'
+            info: 'Hemos recibido tu solicitud de desistimiento del pedido %orderNumber%. Nuestro equipo la revisará y confirmará el desistimiento en breve.'
+
+        withdrawal_confirmed:
+            subject: 'Desistimiento del pedido confirmado #%returnNumber%'
+            greeting: 'Hola'
+            info: 'Tu desistimiento del pedido %orderNumber% ha sido confirmado y el pedido ha sido cancelado.'
+
+        withdrawal_fallback:
+            subject: 'Tu desistimiento se gestionará como una devolución #%returnNumber%'
+            greeting: 'Hola'
+            info: 'Tu solicitud de desistimiento del pedido %orderNumber% se gestionará a través de nuestro proceso de devolución estándar. Nos pondremos en contacto contigo con los siguientes pasos.'
+
+        withdrawal_cancelled:
+            subject: 'Pedido desistido #%returnNumber%'
+            greeting: 'Hola'
+            info: 'Tu pedido %orderNumber% ha sido retirado. Como no se había pagado, no hay nada más que hacer.'

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -1,0 +1,54 @@
+madcoders_rma:
+    email:
+        order_return_form:
+            subject: 'Retour de la commande #%returnNumber%'
+            greeting: 'Bonjour %name%'
+            info_pdf: 'Votre demande de retour a été enregistrée. Veuillez imprimer le formulaire de retour joint et le renvoyer avec votre colis.'
+            info_no_pdf: 'Votre demande de retour a été enregistrée. Veuillez conserver cet e-mail comme confirmation de retour - il n''y a rien à imprimer ni à envoyer. Nous vous contacterons pour les prochaines étapes.'
+
+        order_return_auth_email:
+            subject: 'Code de vérification du retour'
+            order_info: 'Ce code de vérification concerne la commande %orderNumber%.'
+            auth_code_info: 'pour poursuivre le processus de retour, veuillez saisir le code %auth_code% sur'
+            verification_page: 'la page de vérification'
+
+        summary:
+            return_number: 'Numéro de retour'
+            order_number: 'Numéro de commande'
+            status: 'Statut'
+            items: 'Articles'
+            item: 'Article'
+            sku: 'SKU'
+            quantity: 'Quantité'
+            reason: 'Motif'
+            refund_details: 'Coordonnées de remboursement'
+            bank_account_number: 'IBAN'
+            account_holder_name: 'Titulaire du compte'
+            bank_name: 'Banque'
+            state:
+                draft: 'Brouillon'
+                new: 'Nouveau'
+                completed: 'Terminé'
+                canceled: 'Annulé'
+                withdrawal_request: 'Rétractation demandée'
+                withdrawn: 'Rétractée'
+
+        withdrawal_requested:
+            subject: 'Demande de rétractation reçue #%returnNumber%'
+            greeting: 'Bonjour'
+            info: 'Nous avons bien reçu votre demande de rétractation pour la commande %orderNumber%. Notre équipe va l''examiner et confirmer la rétractation sous peu.'
+
+        withdrawal_confirmed:
+            subject: 'Rétractation de la commande confirmée #%returnNumber%'
+            greeting: 'Bonjour'
+            info: 'Votre rétractation pour la commande %orderNumber% a été confirmée et la commande a été annulée.'
+
+        withdrawal_fallback:
+            subject: 'Votre rétractation sera traitée comme un retour #%returnNumber%'
+            greeting: 'Bonjour'
+            info: 'Votre demande de rétractation pour la commande %orderNumber% sera traitée via notre processus de retour standard. Nous vous contacterons pour les prochaines étapes.'
+
+        withdrawal_cancelled:
+            subject: 'Commande rétractée #%returnNumber%'
+            greeting: 'Bonjour'
+            info: 'Votre commande %orderNumber% a été rétractée. Comme elle n''a pas été payée, il n''y a rien de plus à faire.'

--- a/src/Resources/translations/messages.it.yaml
+++ b/src/Resources/translations/messages.it.yaml
@@ -1,0 +1,54 @@
+madcoders_rma:
+    email:
+        order_return_form:
+            subject: 'Reso dell''ordine #%returnNumber%'
+            greeting: 'Ciao %name%'
+            info_pdf: 'La tua richiesta di reso è stata registrata. Stampa il modulo di reso allegato e rispediscilo insieme al pacco.'
+            info_no_pdf: 'La tua richiesta di reso è stata registrata. Conserva questa e-mail come conferma del reso - non c''è nulla da stampare o spedire. Ti contatteremo per i passaggi successivi.'
+
+        order_return_auth_email:
+            subject: 'Codice di verifica del reso'
+            order_info: 'Questo codice di verifica riguarda l''ordine %orderNumber%.'
+            auth_code_info: 'per continuare la procedura di reso, inserisci il codice %auth_code% su'
+            verification_page: 'la pagina di verifica'
+
+        summary:
+            return_number: 'Numero di reso'
+            order_number: 'Numero ordine'
+            status: 'Stato'
+            items: 'Articoli'
+            item: 'Articolo'
+            sku: 'SKU'
+            quantity: 'Quantità'
+            reason: 'Motivo'
+            refund_details: 'Dati per il rimborso'
+            bank_account_number: 'IBAN'
+            account_holder_name: 'Intestatario del conto'
+            bank_name: 'Banca'
+            state:
+                draft: 'Bozza'
+                new: 'Nuovo'
+                completed: 'Completato'
+                canceled: 'Annullato'
+                withdrawal_request: 'Recesso richiesto'
+                withdrawn: 'Recesso effettuato'
+
+        withdrawal_requested:
+            subject: 'Richiesta di recesso ricevuta #%returnNumber%'
+            greeting: 'Salve'
+            info: 'Abbiamo ricevuto la tua richiesta di recesso per l''ordine %orderNumber%. Il nostro team la esaminerà e confermerà il recesso a breve.'
+
+        withdrawal_confirmed:
+            subject: 'Recesso dall''ordine confermato #%returnNumber%'
+            greeting: 'Salve'
+            info: 'Il tuo recesso dall''ordine %orderNumber% è stato confermato e l''ordine è stato annullato.'
+
+        withdrawal_fallback:
+            subject: 'Il tuo recesso sarà gestito come un reso #%returnNumber%'
+            greeting: 'Salve'
+            info: 'La tua richiesta di recesso per l''ordine %orderNumber% sarà gestita tramite la nostra procedura di reso standard. Ti contatteremo per i passaggi successivi.'
+
+        withdrawal_cancelled:
+            subject: 'Recesso effettuato #%returnNumber%'
+            greeting: 'Salve'
+            info: 'Il tuo ordine %orderNumber% è stato revocato. Poiché non era stato pagato, non occorre fare altro.'

--- a/src/Resources/translations/messages.pl.yaml
+++ b/src/Resources/translations/messages.pl.yaml
@@ -1,0 +1,54 @@
+madcoders_rma:
+    email:
+        order_return_form:
+            subject: 'Zwrot zamówienia #%returnNumber%'
+            greeting: 'Dzień dobry %name%'
+            info_pdf: 'Twoje zgłoszenie zwrotu zostało zarejestrowane. Wydrukuj załączony formularz zwrotu i odeślij go wraz z paczką.'
+            info_no_pdf: 'Twoje zgłoszenie zwrotu zostało zarejestrowane. Zachowaj tę wiadomość jako potwierdzenie zwrotu - nie musisz niczego drukować ani wysyłać. Skontaktujemy się z Tobą w sprawie kolejnych kroków.'
+
+        order_return_auth_email:
+            subject: 'Kod weryfikacyjny zwrotu zamówienia'
+            order_info: 'Ten kod weryfikacyjny dotyczy zamówienia %orderNumber%.'
+            auth_code_info: 'aby kontynuować proces zwrotu, wprowadź kod %auth_code% na'
+            verification_page: 'stronie weryfikacji'
+
+        summary:
+            return_number: 'Numer zwrotu'
+            order_number: 'Numer zamówienia'
+            status: 'Status'
+            items: 'Produkty'
+            item: 'Produkt'
+            sku: 'SKU'
+            quantity: 'Ilość'
+            reason: 'Powód'
+            refund_details: 'Dane do zwrotu środków'
+            bank_account_number: 'IBAN'
+            account_holder_name: 'Właściciel rachunku'
+            bank_name: 'Bank'
+            state:
+                draft: 'Szkic'
+                new: 'Nowy'
+                completed: 'Zakończony'
+                canceled: 'Anulowany'
+                withdrawal_request: 'Żądanie odstąpienia'
+                withdrawn: 'Odstąpiono'
+
+        withdrawal_requested:
+            subject: 'Otrzymano żądanie odstąpienia #%returnNumber%'
+            greeting: 'Dzień dobry'
+            info: 'Otrzymaliśmy Twoje żądanie odstąpienia od zamówienia %orderNumber%. Nasz zespół wkrótce je rozpatrzy i potwierdzi odstąpienie.'
+
+        withdrawal_confirmed:
+            subject: 'Potwierdzono odstąpienie od zamówienia #%returnNumber%'
+            greeting: 'Dzień dobry'
+            info: 'Twoje odstąpienie od zamówienia %orderNumber% zostało potwierdzone, a zamówienie zostało anulowane.'
+
+        withdrawal_fallback:
+            subject: 'Twoje odstąpienie zostanie obsłużone jako zwrot #%returnNumber%'
+            greeting: 'Dzień dobry'
+            info: 'Twoje żądanie odstąpienia od zamówienia %orderNumber% zostanie obsłużone w ramach standardowego procesu zwrotu. Skontaktujemy się z Tobą w sprawie kolejnych kroków.'
+
+        withdrawal_cancelled:
+            subject: 'Odstąpiono od zamówienia #%returnNumber%'
+            greeting: 'Dzień dobry'
+            info: 'Twoje zamówienie %orderNumber% zostało wycofane. Ponieważ nie zostało opłacone, nie są wymagane żadne dalsze działania.'

--- a/src/Resources/translations/messages.sv.yaml
+++ b/src/Resources/translations/messages.sv.yaml
@@ -1,0 +1,54 @@
+madcoders_rma:
+    email:
+        order_return_form:
+            subject: 'Retur av order #%returnNumber%'
+            greeting: 'Hej %name%'
+            info_pdf: 'Din returbegäran har registrerats. Skriv ut det bifogade returformuläret och skicka tillbaka det tillsammans med ditt paket.'
+            info_no_pdf: 'Din returbegäran har registrerats. Spara detta e-postmeddelande som din returbekräftelse - det finns inget att skriva ut eller skicka. Vi kontaktar dig med nästa steg.'
+
+        order_return_auth_email:
+            subject: 'Verifieringskod för retur'
+            order_info: 'Den här verifieringskoden gäller order %orderNumber%.'
+            auth_code_info: 'för att fortsätta returprocessen, ange koden %auth_code% på'
+            verification_page: 'verifieringssidan'
+
+        summary:
+            return_number: 'Returnummer'
+            order_number: 'Ordernummer'
+            status: 'Status'
+            items: 'Artiklar'
+            item: 'Artikel'
+            sku: 'SKU'
+            quantity: 'Antal'
+            reason: 'Anledning'
+            refund_details: 'Återbetalningsuppgifter'
+            bank_account_number: 'IBAN'
+            account_holder_name: 'Kontoinnehavare'
+            bank_name: 'Bank'
+            state:
+                draft: 'Utkast'
+                new: 'Ny'
+                completed: 'Slutförd'
+                canceled: 'Avbruten'
+                withdrawal_request: 'Ångerrätt begärd'
+                withdrawn: 'Ångrad'
+
+        withdrawal_requested:
+            subject: 'Begäran om ångerrätt mottagen #%returnNumber%'
+            greeting: 'Hej'
+            info: 'Vi har tagit emot din begäran om att ångra order %orderNumber%. Vårt team granskar den och bekräftar ångerrätten inom kort.'
+
+        withdrawal_confirmed:
+            subject: 'Ångerrätt för order bekräftad #%returnNumber%'
+            greeting: 'Hej'
+            info: 'Din ångerrätt för order %orderNumber% har bekräftats och ordern har annullerats.'
+
+        withdrawal_fallback:
+            subject: 'Din ångerrätt hanteras som en retur #%returnNumber%'
+            greeting: 'Hej'
+            info: 'Din begäran om ångerrätt för order %orderNumber% hanteras via vår vanliga returprocess. Vi kontaktar dig med nästa steg.'
+
+        withdrawal_cancelled:
+            subject: 'Order ångrad #%returnNumber%'
+            greeting: 'Hej'
+            info: 'Din order %orderNumber% har ångrats. Eftersom den inte var betald finns det inget mer att göra.'

--- a/src/Resources/views/Email/_footer.html.twig
+++ b/src/Resources/views/Email/_footer.html.twig
@@ -1,0 +1,20 @@
+{#
+This file is part of package:
+Sylius RMA Plugin
+
+@copyright MADCODERS Team (www.madcoders.co)
+@licence For the full copyright and license information, please view the LICENSE
+
+Overridable e-mail footer - integration point for the shop's branding. Override it in your app at
+templates/bundles/MadcodersSyliusRmaPlugin/Email/_footer.html.twig to render your own signature/links.
+Receives `channel` from the e-mail context when available; degrades gracefully when it is not.
+#}
+{% if channel is defined and channel is not null %}
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="width:100%;margin:24px 0 0;">
+        <tr>
+            <td style="padding-top:12px;border-top:1px solid #eeeeee;font-family:Arial,Helvetica,sans-serif;font-size:12px;color:#888888;">
+                {{ channel.name }}
+            </td>
+        </tr>
+    </table>
+{% endif %}

--- a/src/Resources/views/Email/_header.html.twig
+++ b/src/Resources/views/Email/_header.html.twig
@@ -1,0 +1,20 @@
+{#
+This file is part of package:
+Sylius RMA Plugin
+
+@copyright MADCODERS Team (www.madcoders.co)
+@licence For the full copyright and license information, please view the LICENSE
+
+Overridable e-mail header - integration point for the shop's branding. Override it in your app at
+templates/bundles/MadcodersSyliusRmaPlugin/Email/_header.html.twig to render your own logo/header.
+Receives `channel` from the e-mail context when available; degrades gracefully when it is not.
+#}
+{% if channel is defined and channel is not null %}
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="width:100%;margin:0 0 16px;">
+        <tr>
+            <td style="font-family:Arial,Helvetica,sans-serif;font-size:18px;font-weight:bold;color:#1a1a1a;">
+                {{ channel.name }}
+            </td>
+        </tr>
+    </table>
+{% endif %}

--- a/src/Resources/views/Email/_returnSummary.html.twig
+++ b/src/Resources/views/Email/_returnSummary.html.twig
@@ -1,0 +1,78 @@
+{#
+This file is part of package:
+Sylius RMA Plugin
+
+@copyright MADCODERS Team (www.madcoders.co)
+@licence For the full copyright and license information, please view the LICENSE
+
+Shared return summary for e-mails: return (RMA) number, order number, status, the related items,
+the reason and the refund (bank) details. Renders only from `orderReturn`; optional blocks are
+guarded so the e-mail still renders when items are empty or refund details are missing.
+#}
+{% set summaryItems = orderReturn.items|filter(item => item.returnQty > 0) %}
+
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="width:100%;margin:16px 0;font-family:Arial,Helvetica,sans-serif;font-size:14px;color:#333333;line-height:1.5;">
+    <tr>
+        <td><strong>{{ 'madcoders_rma.email.summary.return_number'|trans }}:</strong> {{ orderReturn.returnNumber }}</td>
+    </tr>
+    <tr>
+        <td><strong>{{ 'madcoders_rma.email.summary.order_number'|trans }}:</strong> {{ orderReturn.orderNumber }}</td>
+    </tr>
+    <tr>
+        <td><strong>{{ 'madcoders_rma.email.summary.status'|trans }}:</strong> {{ ('madcoders_rma.email.summary.state.' ~ orderReturn.orderReturnStatus)|trans }}</td>
+    </tr>
+</table>
+
+{% if summaryItems is not empty %}
+    <p style="margin:16px 0 6px;font-family:Arial,Helvetica,sans-serif;font-size:14px;color:#333333;">
+        <strong>{{ 'madcoders_rma.email.summary.items'|trans }}</strong>
+    </p>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="width:100%;border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;font-size:14px;color:#333333;">
+        <thead>
+            <tr>
+                <th align="left" style="padding:8px;border-bottom:2px solid #dddddd;">{{ 'madcoders_rma.email.summary.item'|trans }}</th>
+                <th align="left" style="padding:8px;border-bottom:2px solid #dddddd;">{{ 'madcoders_rma.email.summary.sku'|trans }}</th>
+                <th align="right" style="padding:8px;border-bottom:2px solid #dddddd;">{{ 'madcoders_rma.email.summary.quantity'|trans }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for item in summaryItems %}
+                <tr>
+                    <td style="padding:8px;border-bottom:1px solid #eeeeee;"><strong>{{ item.productName ?? item.productSku }}</strong></td>
+                    <td style="padding:8px;border-bottom:1px solid #eeeeee;">{{ item.productSku }}</td>
+                    <td align="right" style="padding:8px;border-bottom:1px solid #eeeeee;">{{ item.returnQty }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+
+{% if orderReturn.returnReason %}
+    <p style="margin:16px 0 0;font-family:Arial,Helvetica,sans-serif;font-size:14px;color:#333333;">
+        <strong>{{ 'madcoders_rma.email.summary.reason'|trans }}:</strong> {{ orderReturn.returnReason }}
+    </p>
+{% endif %}
+
+{% if orderReturn.bankAccountNumber %}
+    <p style="margin:16px 0 6px;font-family:Arial,Helvetica,sans-serif;font-size:14px;color:#333333;">
+        <strong>{{ 'madcoders_rma.email.summary.refund_details'|trans }}</strong>
+    </p>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="font-family:Arial,Helvetica,sans-serif;font-size:14px;color:#333333;line-height:1.5;">
+        <tr>
+            <td style="padding:0 16px 0 0;"><strong>{{ 'madcoders_rma.email.summary.bank_account_number'|trans }}:</strong></td>
+            <td>{{ orderReturn.bankAccountNumber }}</td>
+        </tr>
+        {% if orderReturn.accountHolderName %}
+            <tr>
+                <td style="padding:0 16px 0 0;"><strong>{{ 'madcoders_rma.email.summary.account_holder_name'|trans }}:</strong></td>
+                <td>{{ orderReturn.accountHolderName }}</td>
+            </tr>
+        {% endif %}
+        {% if orderReturn.bankName %}
+            <tr>
+                <td style="padding:0 16px 0 0;"><strong>{{ 'madcoders_rma.email.summary.bank_name'|trans }}:</strong></td>
+                <td>{{ orderReturn.bankName }}</td>
+            </tr>
+        {% endif %}
+    </table>
+{% endif %}

--- a/src/Resources/views/Email/authCodeGenerated.html.twig
+++ b/src/Resources/views/Email/authCodeGenerated.html.twig
@@ -17,15 +17,16 @@ Architects of this package:
 {% block body %}
     {% set url = channel.hostname is not null ? 'https://' ~ channel.hostname ~ path('madcoders_rma_verification', { 'code': authCode.hash }) : url('madcoders_rma_verification', { 'code': authCode.hash }) %}
 
+    {% include '@MadcodersSyliusRmaPlugin/Email/_header.html.twig' %}
+
     {% autoescape %}
         Hello,<br>
         <br>
-
-        {# @todo add extension point: mail before content #}
-
+        {{ 'madcoders_rma.email.order_return_auth_email.order_info'|trans({ '%orderNumber%': authCode.orderNumber }) }}<br>
+        <br>
         {{ 'madcoders_rma.email.order_return_auth_email.auth_code_info'|trans({ '%auth_code%': authCode.authCode }) }}
         <a target="_blank" href="{{ url }}">{{ 'madcoders_rma.email.order_return_auth_email.verification_page'|trans }}</a>.
-
-        {# @todo add extension point: mail after content #}
     {% endautoescape %}
+
+    {% include '@MadcodersSyliusRmaPlugin/Email/_footer.html.twig' %}
 {% endblock %}

--- a/src/Resources/views/Email/returnFormGenerated.html.twig
+++ b/src/Resources/views/Email/returnFormGenerated.html.twig
@@ -3,9 +3,19 @@
 {% endblock %}
 
 {% block body %}
+    {% include '@MadcodersSyliusRmaPlugin/Email/_header.html.twig' %}
+
     {% autoescape %}
         {{ 'madcoders_rma.email.order_return_form.greeting'|trans({ '%name%': orderReturn.returnNumber }) }},<br>
         <br>
-        {{ 'madcoders_rma.email.order_return_form.info'|trans }},<br>
+        {% if madcoders_rma_return_form_pdf_enabled() %}
+            {{ 'madcoders_rma.email.order_return_form.info_pdf'|trans }}<br>
+        {% else %}
+            {{ 'madcoders_rma.email.order_return_form.info_no_pdf'|trans }}<br>
+        {% endif %}
     {% endautoescape %}
+
+    {% include '@MadcodersSyliusRmaPlugin/Email/_returnSummary.html.twig' %}
+
+    {% include '@MadcodersSyliusRmaPlugin/Email/_footer.html.twig' %}
 {% endblock %}

--- a/src/Resources/views/Email/withdrawalCancelled.html.twig
+++ b/src/Resources/views/Email/withdrawalCancelled.html.twig
@@ -3,9 +3,15 @@
 {% endblock %}
 
 {% block body %}
+    {% include '@MadcodersSyliusRmaPlugin/Email/_header.html.twig' %}
+
     {% autoescape %}
         {{ 'madcoders_rma.email.withdrawal_cancelled.greeting'|trans }},<br>
         <br>
         {{ 'madcoders_rma.email.withdrawal_cancelled.info'|trans({ '%orderNumber%': orderReturn.orderNumber }) }}<br>
     {% endautoescape %}
+
+    {% include '@MadcodersSyliusRmaPlugin/Email/_returnSummary.html.twig' %}
+
+    {% include '@MadcodersSyliusRmaPlugin/Email/_footer.html.twig' %}
 {% endblock %}

--- a/src/Resources/views/Email/withdrawalConfirmed.html.twig
+++ b/src/Resources/views/Email/withdrawalConfirmed.html.twig
@@ -3,9 +3,15 @@
 {% endblock %}
 
 {% block body %}
+    {% include '@MadcodersSyliusRmaPlugin/Email/_header.html.twig' %}
+
     {% autoescape %}
         {{ 'madcoders_rma.email.withdrawal_confirmed.greeting'|trans }},<br>
         <br>
         {{ 'madcoders_rma.email.withdrawal_confirmed.info'|trans({ '%orderNumber%': orderReturn.orderNumber }) }}<br>
     {% endautoescape %}
+
+    {% include '@MadcodersSyliusRmaPlugin/Email/_returnSummary.html.twig' %}
+
+    {% include '@MadcodersSyliusRmaPlugin/Email/_footer.html.twig' %}
 {% endblock %}

--- a/src/Resources/views/Email/withdrawalFallback.html.twig
+++ b/src/Resources/views/Email/withdrawalFallback.html.twig
@@ -3,9 +3,15 @@
 {% endblock %}
 
 {% block body %}
+    {% include '@MadcodersSyliusRmaPlugin/Email/_header.html.twig' %}
+
     {% autoescape %}
         {{ 'madcoders_rma.email.withdrawal_fallback.greeting'|trans }},<br>
         <br>
         {{ 'madcoders_rma.email.withdrawal_fallback.info'|trans({ '%orderNumber%': orderReturn.orderNumber }) }}<br>
     {% endautoescape %}
+
+    {% include '@MadcodersSyliusRmaPlugin/Email/_returnSummary.html.twig' %}
+
+    {% include '@MadcodersSyliusRmaPlugin/Email/_footer.html.twig' %}
 {% endblock %}

--- a/src/Resources/views/Email/withdrawalRequested.html.twig
+++ b/src/Resources/views/Email/withdrawalRequested.html.twig
@@ -3,9 +3,15 @@
 {% endblock %}
 
 {% block body %}
+    {% include '@MadcodersSyliusRmaPlugin/Email/_header.html.twig' %}
+
     {% autoescape %}
         {{ 'madcoders_rma.email.withdrawal_requested.greeting'|trans }},<br>
         <br>
         {{ 'madcoders_rma.email.withdrawal_requested.info'|trans({ '%orderNumber%': orderReturn.orderNumber }) }}<br>
     {% endautoescape %}
+
+    {% include '@MadcodersSyliusRmaPlugin/Email/_returnSummary.html.twig' %}
+
+    {% include '@MadcodersSyliusRmaPlugin/Email/_footer.html.twig' %}
 {% endblock %}

--- a/tests/Behat/Context/Ui/Shop/Rma/ReturnSuccessContext.php
+++ b/tests/Behat/Context/Ui/Shop/Rma/ReturnSuccessContext.php
@@ -105,6 +105,43 @@ class ReturnSuccessContext implements Context
     }
 
     /**
+     * Asserts the confirmation e-mail carries the self-contained summary: the return number, the
+     * order number (rendered only by the summary block, not the greeting) and - since the PDF is off
+     * by default - the "no PDF, this e-mail is your confirmation" notice.
+     *
+     * @Then /^the order return confirmation email to "([^"]+)" should contain the return summary for (latest order)$/
+     */
+    public function theConfirmationEmailShouldContainTheReturnSummary(string $recipient, OrderInterface $order, string $localeCode = 'en_US'): void
+    {
+        $orderNumber = $order->getNumber() ?? '';
+        $returnNumber = $this->findNewReturnFormByOrderNumber($orderNumber);
+
+        Assert::true($this->emailChecker->hasMessageTo($returnNumber, $recipient));
+        Assert::true($this->emailChecker->hasMessageTo(str_replace('#', '', $orderNumber), $recipient));
+
+        $noPdfNotice = $this->translator->trans(
+            'madcoders_rma.email.order_return_form.info_no_pdf',
+            [],
+            null,
+            $localeCode,
+        );
+
+        Assert::true($this->emailChecker->hasMessageTo($noPdfNotice, $recipient));
+    }
+
+    /**
+     * Asserts the confirmation e-mail lists the returned item and renders the refund (bank) details.
+     *
+     * @Then /^the order return confirmation email to "([^"]+)" should list item "([^"]+)" and refund details "([^"]+)" and "([^"]+)"$/
+     */
+    public function theConfirmationEmailShouldListItemAndRefundDetails(string $recipient, string $itemName, string $accountHolder, string $bankName): void
+    {
+        Assert::true($this->emailChecker->hasMessageTo($itemName, $recipient));
+        Assert::true($this->emailChecker->hasMessageTo($accountHolder, $recipient));
+        Assert::true($this->emailChecker->hasMessageTo($bankName, $recipient));
+    }
+
+    /**
      * @throws \Exception
      */
     private function findNewReturnFormByOrderNumber(string $orderNumber): string

--- a/tests/Behat/Context/Ui/Shop/Rma/WithdrawalContext.php
+++ b/tests/Behat/Context/Ui/Shop/Rma/WithdrawalContext.php
@@ -152,6 +152,21 @@ final class WithdrawalContext implements Context
     }
 
     /**
+     * Asserts the withdrawal e-mail carries the self-contained summary: the return number, the order
+     * number and the withdrawn item (proving the items table renders).
+     *
+     * @Then /^the withdrawal email to "([^"]+)" should contain the return summary with item "([^"]+)" for (latest order)$/
+     */
+    public function theWithdrawalEmailShouldContainTheReturnSummary(string $recipient, string $productName, OrderInterface $order): void
+    {
+        $orderReturn = $this->findReturnForOrder($order);
+
+        Assert::true($this->emailChecker->hasMessageTo($orderReturn->getReturnNumber(), $recipient));
+        Assert::true($this->emailChecker->hasMessageTo($orderReturn->getOrderNumber(), $recipient));
+        Assert::true($this->emailChecker->hasMessageTo($productName, $recipient));
+    }
+
+    /**
      * @Then /^order return for (latest order) should have a "([^"]+)" change-log entry authored by a (customer|admin)$/
      */
     public function orderReturnForOrderShouldHaveChangeLogEntryAuthoredBy(OrderInterface $order, string $type, string $authorType): void

--- a/tests/Unit/Email/WithdrawalEmailSenderTest.php
+++ b/tests/Unit/Email/WithdrawalEmailSenderTest.php
@@ -21,6 +21,8 @@ use Madcoders\SyliusRmaPlugin\Email\WithdrawalEmailSender;
 use Madcoders\SyliusRmaPlugin\Entity\OrderReturnInterface;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Tests\Madcoders\SyliusRmaPlugin\Unit\UnitTestCase;
 
@@ -29,6 +31,8 @@ final class WithdrawalEmailSenderTest extends UnitTestCase
     use ProphecyTrait;
 
     private const RECIPIENT = 'john.doe@madcoders.pl';
+
+    private const CHANNEL_CODE = 'WEB';
 
     /**
      * @return array<string, array{0: string, 1: string}>
@@ -45,22 +49,31 @@ final class WithdrawalEmailSenderTest extends UnitTestCase
 
     /**
      * @test
+     *
      * @dataProvider emailMethods
      */
-    public function it_sends_the_matching_email_to_the_customer(string $method, string $expectedCode): void
+    public function it_sends_the_matching_email_with_the_return_and_channel(string $method, string $expectedCode): void
     {
+        $channel = $this->prophesize(ChannelInterface::class)->reveal();
+
         $orderReturn = $this->prophesize(OrderReturnInterface::class);
         $orderReturn->getCustomerEmail()->willReturn(self::RECIPIENT);
+        $orderReturn->getChannelCode()->willReturn(self::CHANNEL_CODE);
+        $orderReturnRevealed = $orderReturn->reveal();
+
+        $channelRepository = $this->prophesize(ChannelRepositoryInterface::class);
+        $channelRepository->findOneByCode(self::CHANNEL_CODE)->willReturn($channel);
 
         $emailSender = $this->prophesize(SenderInterface::class);
         $emailSender->send(
             $expectedCode,
             [self::RECIPIENT],
-            Argument::that(static fn (array $data): bool => array_key_exists('orderReturn', $data)),
+            Argument::that(static fn (array $data): bool => ($data['orderReturn'] ?? null) === $orderReturnRevealed &&
+                ($data['channel'] ?? null) === $channel),
         )->shouldBeCalledOnce();
 
-        $sender = new WithdrawalEmailSender($emailSender->reveal());
-        $sender->{$method}($orderReturn->reveal());
+        $sender = new WithdrawalEmailSender($emailSender->reveal(), $channelRepository->reveal());
+        $sender->{$method}($orderReturnRevealed);
     }
 
     /** @test */
@@ -69,10 +82,13 @@ final class WithdrawalEmailSenderTest extends UnitTestCase
         $orderReturn = $this->prophesize(OrderReturnInterface::class);
         $orderReturn->getCustomerEmail()->willReturn(null);
 
+        $channelRepository = $this->prophesize(ChannelRepositoryInterface::class);
+        $channelRepository->findOneByCode(Argument::any())->shouldNotBeCalled();
+
         $emailSender = $this->prophesize(SenderInterface::class);
         $emailSender->send(Argument::cetera())->shouldNotBeCalled();
 
-        $sender = new WithdrawalEmailSender($emailSender->reveal());
+        $sender = new WithdrawalEmailSender($emailSender->reveal(), $channelRepository->reveal());
         $sender->sendWithdrawalRequestedEmail($orderReturn->reveal());
     }
 }


### PR DESCRIPTION
Closes #23.

Makes every customer RMA e-mail a complete, branded, localized record, so it stands on its own when the return-form PDF is off (the default).

## What changed
- **Shared partials** (`src/Resources/views/Email/`): `_returnSummary.html.twig` (RMA number, order number, status, an items table, reason, and full refund/bank details - all from `orderReturn`, optional blocks guarded) and overridable **`_header`/`_footer`** branding integration points.
- **All 6 templates** rewired as header → content → summary → footer. The return-confirmation e-mail branches its instructions on `madcoders_rma_return_form_pdf_enabled()`; the verification e-mail now shows its order number (it has no return yet, so no RMA/items).
- **`WithdrawalEmailSender`** resolves and passes the `channel` (via the channel repository) so header/footer can render shop branding; the return/auth senders already had it.
- **Item rows** = product name + SKU + qty; **full** bank details (IBAN, account holder, bank name); clean table-based HTML with bold labels.
- **8 locales** (en, pl, de, fr, it, es, sv, da) under `madcoders_rma.email.*`; replaced the misleading "print attached form" string with PDF-on/off variants.
- README documents the e-mail content and the header/footer override path.

## Verification
- 72 unit tests pass (incl. updated `WithdrawalEmailSenderTest` for the channel dependency).
- PHPStan, ECS, Rector clean; YAML + Twig lint clean; test container compiles.
- Rendered the actual e-mail bodies via Twig to confirm header/footer, the PDF branch, and the summary block (state label, items table, refund details).

## Follow-up
- Existing Behat email scenarios keep their preserved `greeting`/`info` keys (no regression). New body-content + PDF-branch Behat assertions (issue AC #8) are still to be added and are best verified in CI.

See issue #23 for the rendered English example of each e-mail.