### PR TITLE
fix(security): send the return document to the order's customer (#28)

### DIFF
--- a/src/Controller/ReturnController.php
+++ b/src/Controller/ReturnController.php
@@ -32,6 +32,7 @@ use Madcoders\SyliusRmaPlugin\Services\RmaVerificationPossibilityOfReturn;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -179,7 +180,12 @@ final class ReturnController extends AbstractController
                 $userLastName = 'no Last Name';
             }
 
-            $customerEmail = $orderReturn->getCustomerEmail();
+            // Re-derive the recipient from the order's customer rather than the customer-editable
+            // customerEmail submitted on the return form. The return document (and, when enabled,
+            // the attached PDF) carries the customer's name, address and order lines, so it must
+            // not be redirectable to an arbitrary address (see security issue #28).
+            $customer = $order->getCustomer();
+            $customerEmail = $customer instanceof CustomerInterface ? $customer->getEmail() : null;
             if (null === $customerEmail || '' === $customerEmail) {
                 $customerEmail = 'no email address';
             }

--- a/src/Form/Type/ReturnFormType.php
+++ b/src/Form/Type/ReturnFormType.php
@@ -29,6 +29,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 class ReturnFormType extends AbstractType
@@ -71,6 +72,14 @@ class ReturnFormType extends AbstractType
             ->add('customerEmail', TextType::class, [
                 'required' => true,
                 'label' => 'sylius.ui.email',
+                'constraints' => [
+                    new NotBlank([
+                        'message' => 'madcoders_rma.validator.not_blank',
+                    ]),
+                    new Email([
+                        'message' => 'madcoders_rma.validator.email.not_a_valid',
+                    ]),
+                ],
             ])
             ->add('company', TextType::class, [
                 'required' => false,

--- a/src/Resources/translations/validators.en.yaml
+++ b/src/Resources/translations/validators.en.yaml
@@ -11,6 +11,8 @@ madcoders_rma:
             not_blank: 'Please enter the account holder name'
         bank_name:
             not_blank: 'Please enter the bank name / BIC-SWIFT'
+        email:
+            not_a_valid: 'Please enter a valid e-mail address'
         notes:
             not_blank: 'This field cannot be empty'
         days_to_deadline_to_return:

--- a/tests/Unit/Form/Type/ReturnFormTypeTest.php
+++ b/tests/Unit/Form/Type/ReturnFormTypeTest.php
@@ -22,6 +22,7 @@ use Madcoders\SyliusRmaPlugin\Services\Reason\ChoiceProviderInterface;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Iban;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Tests\Madcoders\SyliusRmaPlugin\Unit\UnitTestCase;
@@ -64,6 +65,23 @@ class ReturnFormTypeTest extends UnitTestCase
             ->shouldHaveBeenCalled();
         $builder->add('accountHolderName', Argument::cetera())->shouldNotHaveBeenCalled();
         $builder->add('bankName', Argument::cetera())->shouldNotHaveBeenCalled();
+    }
+
+    /** @test */
+    function the_customer_email_field_must_be_a_valid_email(): void
+    {
+        // the customerEmail value must be a syntactically valid address; the return document
+        // recipient is re-derived from the order server-side (see security issue #28)
+        $builder = $this->prophesize(FormBuilderInterface::class);
+        $double = $builder->reveal();
+        $builder->add(Argument::cetera())->willReturn($double);
+        $builder->addEventListener(Argument::cetera())->willReturn($double);
+
+        $returnForm = new ReturnFormType($this->prophesize(ChoiceProviderInterface::class)->reveal());
+        $returnForm->buildForm($double, []);
+
+        $builder->add('customerEmail', Argument::any(), Argument::that($this->hasConstraints(NotBlank::class, Email::class)))
+            ->shouldHaveBeenCalled();
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #28.

The `customerEmail` field on the return form is customer-editable (pre-filled from the order but not locked, and previously with no `Email` constraint). On acceptance, `ReturnController::acceptIndex` used `$orderReturn->getCustomerEmail()` verbatim as the recipient of the return-form e-mail, and, when PDF is enabled, that e-mail carries an attachment with the customer's name, address and order lines. A customer could therefore make the shop deliver their return document to an arbitrary address.

## Change

- **Recipient is re-derived server-side**: `ReturnController::acceptIndex` now takes the recipient from `$order->getCustomer()->getEmail()` (the order already resolved and authorized earlier in the action). The submitted form value is never read for the recipient. The existing `'no email address'` fallback is retained for the edge case of an order with no customer e-mail.
- **Input hygiene**: added `NotBlank` + `Email` constraints to the `customerEmail` form field, plus a new `madcoders_rma.validator.email.not_a_valid` message.

## Tests

- `tests/Unit/Form/Type/ReturnFormTypeTest.php`: asserts the `customerEmail` field carries exactly `NotBlank` + `Email`.
- Acceptance criterion "recipient equals the order/customer e-mail even when a different value is submitted" is now a structural guarantee: the recipient is derived only from `$order->getCustomer()`, so a tampered form value cannot affect it. The existing return-confirmation Behat scenario (`ReturnSuccessContext`, "email ... should be sent to ... for latest order") continues to assert delivery to the customer.

## Notes

- Severity: Low. One PR per issue, as requested.
- Behat/PHPUnit not runnable end-to-end in my environment for the full HTTP path; unit + static (ECS clean, no new PHPStan errors) were run locally under PHP 8.4 (CI runs 8.2).
