### PR TITLE
Sylius 2.2 upgrade: phase 1 scaffold (roadmap, CI gating, composer bump)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,14 @@ name: CI
 
 on:
     push:
-        branches: ["1.0", "1.1", "master", "main"]
+        branches: ["1.0", "1.1", "2.0", "master", "main"]
     pull_request: ~
     workflow_dispatch: ~
+
+# While the Sylius 2 upgrade is in progress on the 2.0 line, the heavy jobs are
+# gated off so the branch stays green with reduced checks. Gates are removed per
+# phase of docs/upgrade-sylius-2/ROADMAP.md (static/unit in phase 3, fixtures in
+# phase 5, behat in phase 8).
 
 concurrency:
     group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -45,20 +50,30 @@ jobs:
                   key: composer-${{ env.PHP_VERSION }}-${{ hashFiles('composer.json') }}
                   restore-keys: composer-${{ env.PHP_VERSION }}-
 
+            - name: Validate composer.json
+              run: composer validate --no-check-lock
+
+            # TODO(sylius-2): re-enable the steps below for the 2.0 line in phase 3
             - name: Install dependencies
+              if: ${{ github.ref_name != '2.0' && github.base_ref != '2.0' }}
               run: composer update --no-interaction --no-progress --prefer-dist --no-scripts
 
             - name: PHPStan
+              if: ${{ github.ref_name != '2.0' && github.base_ref != '2.0' }}
               run: make phpstan
 
             - name: Rector (dry-run)
+              if: ${{ github.ref_name != '2.0' && github.base_ref != '2.0' }}
               run: make rector
 
             - name: ECS
+              if: ${{ github.ref_name != '2.0' && github.base_ref != '2.0' }}
               run: make ecs
 
     unit:
         name: Unit tests (PHPUnit)
+        # TODO(sylius-2): re-enable for the 2.0 line in phase 3
+        if: ${{ github.ref_name != '2.0' && github.base_ref != '2.0' }}
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -90,6 +105,8 @@ jobs:
 
     fixtures:
         name: Fixtures runnable (sylius:fixtures:load)
+        # TODO(sylius-2): re-enable for the 2.0 line in phase 5
+        if: ${{ github.ref_name != '2.0' && github.base_ref != '2.0' }}
         runs-on: ubuntu-latest
         services:
             # Same MySQL service as the Behat job (see docker-compose.yml): the test app's
@@ -138,6 +155,8 @@ jobs:
 
     behat:
         name: Behat (non-JavaScript)
+        # TODO(sylius-2): re-enable for the 2.0 line in phase 8
+        if: ${{ github.ref_name != '2.0' && github.base_ref != '2.0' }}
         runs-on: ubuntu-latest
         services:
             # Mirrors docker-compose.yml: MySQL 8 on host port 3307 with root password "rma",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), and commi
 
 ## [Unreleased]
 
+### Changed
+
+- **Sylius 2 line begins (2.0 branch)**: the plugin now targets `sylius/sylius ^2.2`
+  (Symfony ^6.4 || ^7.x, PHP ^8.2). The migration is phased and tracked in
+  [docs/upgrade-sylius-2/ROADMAP.md](docs/upgrade-sylius-2/ROADMAP.md); until it completes,
+  the 2.0 branch is not installable and CI runs a reduced pipeline. Sylius 1.12 support
+  continues on the 1.x branches.
+
 ## [1.3.0-rc.3] - 2026-06-23
 
 Third release candidate for the 1.3 line, making the RMA e-mails self-contained, branded and

--- a/composer.json
+++ b/composer.json
@@ -23,38 +23,39 @@
     ],
     "require": {
         "php": "^8.2",
-        "knplabs/knp-snappy-bundle": "^1.8",
-        "sylius/sylius": "~1.12.0"
+        "knplabs/knp-snappy-bundle": "^1.10",
+        "sylius/sylius": "^2.2"
     },
     "require-dev": {
-        "behat/behat": "^3.7",
-        "dmore/behat-chrome-extension": "^1.3",
-        "dmore/chrome-mink-driver": "^2.7",
-        "friends-of-behat/mink": "^1.8",
-        "friends-of-behat/mink-browserkit-driver": "^1.4",
-        "friends-of-behat/mink-debug-extension": "^2.0",
-        "friends-of-behat/mink-extension": "^2.4",
+        "behat/behat": "^3.16",
+        "dmore/behat-chrome-extension": "^1.4",
+        "dmore/chrome-mink-driver": "^2.9",
+        "friends-of-behat/mink": "^1.11",
+        "friends-of-behat/mink-browserkit-driver": "^1.6",
+        "friends-of-behat/mink-debug-extension": "^2.1",
+        "friends-of-behat/mink-extension": "^2.7",
         "friends-of-behat/page-object-extension": "^0.3",
-        "friends-of-behat/suite-settings-extension": "^1.0",
-        "friends-of-behat/symfony-extension": "^2.1",
-        "friends-of-behat/variadic-extension": "^1.3",
-        "phpspec/prophecy-phpunit": "^2.0",
+        "friends-of-behat/suite-settings-extension": "^1.1",
+        "friends-of-behat/symfony-extension": "^2.6",
+        "friends-of-behat/variadic-extension": "^1.6",
+        "phpspec/prophecy-phpunit": "^2.1",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^10.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "rector/rector": "^2.0",
-        "sylius-labs/coding-standard": "^4.0",
+        "sylius-labs/coding-standard": "^4.4",
         "sylius/sylius-rector": "^3.7",
-        "symfony/browser-kit": "^6.4",
-        "symfony/debug-bundle": "^6.4",
-        "symfony/dotenv": "^6.4",
-        "symfony/intl": "^6.4",
-        "symfony/web-profiler-bundle": "^6.4",
-        "symfony/webpack-encore-bundle": "^1.15"
+        "symfony/browser-kit": "^6.4 || ^7.1",
+        "symfony/debug-bundle": "^6.4 || ^7.1",
+        "symfony/dotenv": "^6.4 || ^7.1",
+        "symfony/flex": "^2.4",
+        "symfony/intl": "^6.4 || ^7.1",
+        "symfony/web-profiler-bundle": "^6.4 || ^7.1",
+        "symfony/webpack-encore-bundle": "^2.2"
     },
     "config": {
         "allow-plugins": {
@@ -67,13 +68,13 @@
         "sort-packages": true,
         "policy": {
             "advisories": {
-                "ignore": ["api-platform/core", "enshrined/svg-sanitize", "guzzlehttp/guzzle", "guzzlehttp/psr7"]
+                "ignore": ["enshrined/svg-sanitize", "guzzlehttp/guzzle", "guzzlehttp/psr7"]
             }
         }
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.12-dev"
+            "dev-2.0": "2.0-dev"
         }
     },
     "autoload": {

--- a/docs/upgrade-sylius-2/ROADMAP.md
+++ b/docs/upgrade-sylius-2/ROADMAP.md
@@ -1,0 +1,344 @@
+# Sylius 2.2 upgrade roadmap (plugin 2.0 line)
+
+Status: living document. Maintained on the `2.0` branch until `v2.0.0-rc.1` is tagged.
+Owner: madcoders RMA plugin maintainers.
+
+## Goal
+
+Upgrade `madcoders/sylius-rma-plugin` from Sylius `~1.12.0` (PHP 8.2, Symfony 6.4) to
+`sylius/sylius ^2.2` (PHP ^8.2, Symfony ^6.4 || ^7.x). Sylius 2 is a rewrite-level change
+for plugins, so the work is split into phases, each delivered as one or more reviewable
+PRs into the `2.0` branch. One GitHub issue tracks each phase (label `sylius-2`,
+milestone `2.0.0`).
+
+## Branching model
+
+- `2.0` is a new long-lived release branch, cut from the tip of `1.3`
+  (commit `1c8525a`, the `1.3.0-rc.3` merge). It supports Sylius 2 only.
+- The `1.x` branches stay for legacy fixes (Sylius 1.12).
+- Future Sylius 2 minors continue the per-minor convention: `2.1`, `2.2`, ...
+- Topic branches (`feature/*`, `fix/*`) target `2.0` via PRs, as on the 1.x lines.
+
+### Forward-merge obligation
+
+At the time `2.0` was cut, these fixes were NOT yet merged into `1.3` and must be
+forward-merged (or cherry-picked) into `2.0` once they land:
+
+- [ ] `fix/issue-26-authcode-hardening` (auth-code brute-force hardening, `a74a719`)
+- [ ] `fix/issue-27-withdrawal-success-authz`
+- [ ] `fix/issue-28-return-email-recipient`
+
+Check this list before tagging `v2.0.0-rc.1`.
+
+## Phase dependency graph
+
+```
+P1 branch + roadmap + CI scaffold
+  -> P2 composer + test application regeneration (installable)
+    -> P3 rector + PHP-level source fixes (static analysis green)
+      -> P4 state machine: winzou -> symfony workflow
+      -> P5 resource layer: routing, grids, DI, doctrine
+        -> P6 admin UI: twig hooks + Tabler rewrite
+        -> P7 shop UI + emails + PDF
+          -> P8 fixtures + behat + full CI + docs + release
+```
+
+P4 and P5 are independent of each other (both depend on P3). P6 depends on P5.
+P7 depends on P4 and P5. P8 depends on everything.
+
+## CI policy on the 2.0 line
+
+No standing red. While the suite cannot pass, the heavy jobs (`unit`, `fixtures`,
+`behat`, and the rector/ecs steps of `static`) are gated off for the 2.0 line with
+`TODO(sylius-2)` comments in `.github/workflows/ci.yml`. The `static` job keeps at
+least `composer validate` on every push so each commit stays parseable. Gates are
+removed per phase:
+
+| Gate | Re-enabled in |
+|---|---|
+| static: phpstan / rector / ecs steps | P3 |
+| unit | P3 |
+| fixtures | P5 (P8 at the latest) |
+| behat | P8 |
+
+## Phases
+
+### Phase 1: branch, roadmap, CI scaffold (this PR)
+
+- [x] Cut `2.0` from `1.3` tip and push (exact copy of `1c8525a`).
+- [x] Commit this roadmap.
+- [ ] CI: add `2.0` to push triggers; gate heavy jobs for the 2.0 line.
+- [ ] GitHub issues for phases 2 to 8 (label `sylius-2`, milestone `2.0.0`).
+- [ ] Phase 2 groundwork: rewritten `composer.json` targeting `sylius/sylius ^2.2`.
+
+Definition of done: `origin/2.0` exists at `1c8525a`; this PR merged; CI completes
+without red on the PR (gated jobs skipped); 7 phase issues open.
+
+### Phase 2: composer bump + test application regeneration
+
+Goal: `composer update` resolves against `sylius/sylius ^2.2` and the regenerated
+`tests/Application` kernel boots (`cache:clear -e test`) with the plugin enabled.
+
+- [ ] Finish `composer.json` alignment with PluginSkeleton `2.0` branch; delete and
+      regenerate `composer.lock`.
+- [ ] Regenerate `tests/Application` from PluginSkeleton 2.0 layout: new `Kernel.php`,
+      `config/bundles.php` (drop FOSRestBundle, JMSSerializerBundle, BazingaHateoasBundle,
+      SonataBlockBundle, ApiPlatform Core bridge, winzou; add Symfony UX bundles:
+      TwigComponent, LiveComponent, StimulusBundle, TurboBundle, and
+      `Sylius\TwigHooks\SyliusTwigHooksBundle`), `config/packages/`, `config/routes/`,
+      `public/`, `bin/`, `assets/`, `package.json`, `webpack.config.js`, `.env` files.
+- [ ] Re-apply plugin-specific bits: plugin bundle registration, config import of
+      `@MadcodersSyliusRmaPlugin/Resources/config/config.yml`, routing imports
+      (admin under `/admin`, shop under `/{_locale}`), `tests/Application/Entity/`
+      resource overrides (including the `Product` with `NonReturnableProductInterface`),
+      `_sylius.yaml` resource model overrides.
+- [ ] Minimal plugin-config surgery so the container compiles (tracked in the
+      "temporarily disabled" ledger below): remove the `sylius_ui.events` section from
+      `src/Resources/config/config.yml` (real replacement in P6); replace the
+      `winzou_state_machine` block with a minimal `framework.workflows` placeholder
+      (real migration in P4).
+- [ ] Verify `PrependDoctrineMigrationsTrait` and `SyliusPluginTrait` against the
+      resolved Sylius 2.2 packages.
+- [ ] Verify `Sylius\Component\Mailer\Sender\SenderInterface` and the
+      `sylius_mailer.emails` config node still exist (expected: yes).
+- [ ] Migrate `phpunit.xml.dist` to the PHPUnit 10 schema; align Makefile and
+      `behat.yml.dist` paths with the regenerated app.
+- [ ] Decide MockerContainer: keep `polishsymfonycommunity/symfony-mocker-container`
+      if compatible, otherwise adopt the PluginSkeleton 2.0 test-kernel pattern.
+
+Definition of done: `composer validate` and `composer update` succeed;
+`(cd tests/Application && bin/console cache:clear -e test)` succeeds with the plugin
+enabled; `bin/console debug:container madcoders` lists plugin services; lock file
+committed. UI is expected broken at this point.
+
+### Phase 3: rector + PHP-level source fixes
+
+Goal: plugin PHP code compiles against Sylius 2.2 APIs; phpstan, ecs, rector dry-run
+and phpunit green; `static` and `unit` CI gates removed.
+
+- [ ] Update `rector.php` with the sylius/sylius-rector Sylius 2 sets; apply in small
+      commits per set.
+- [ ] Manual API sweep hotspots: `src/Email/*` sender constructors, `src/Controller/*`
+      request-configuration APIs, `src/Form/Extension/*` against Sylius 2 form type
+      FQCNs, `src/Fixture/*` base classes and OptionsResolver signatures, `src/Twig/*`
+      against removed templating helpers.
+- [ ] `src/DependencyInjection/Configuration.php`: drop removed `options` nodes under
+      resources; re-verify the tree against the ResourceBundle shipped with 2.2.
+- [ ] Regenerate `phpstan-baseline.neon`; prefer fixing over baselining
+      (see docs/adr-log and the baseline honesty workflow).
+- [ ] PHPUnit 10 migration for `tests/Unit` (annotations to attributes, prophecy bump).
+
+Definition of done: `make phpstan`, `make ecs`, `make rector`, `make phpunit` green
+locally and in CI; gates removed for `static` steps and `unit`.
+
+### Phase 4: state machine migration (winzou -> symfony workflow)
+
+Goal: the `return_status` graph runs on symfony/workflow behind
+`Sylius\Abstraction\StateMachine\StateMachineInterface`; all callbacks fire as
+workflow event listeners; ADR recorded.
+
+Graph definition replacing the `winzou_state_machine` block in
+`src/Resources/config/config.yml` (keep graph name `return_status` so
+`OrderReturnInterface::GRAPH`, constants, and `_sylius.state_machine` routing values
+stay unchanged):
+
+```yaml
+framework:
+    workflows:
+        return_status:
+            type: state_machine
+            marking_store: { type: method, property: orderReturnStatus }
+            supports:
+                - Madcoders\SyliusRmaPlugin\Entity\OrderReturnInterface
+            initial_marking: draft
+            places: [draft, new, completed, canceled, withdrawal_request, withdrawn]
+            transitions:
+                new: { from: draft, to: new }
+                complete: { from: new, to: completed }
+                cancel: { from: [draft, new], to: canceled }
+                request_withdrawal: { from: draft, to: withdrawal_request }
+                # two same-named transitions preserve winzou from-scoped callbacks
+                withdraw: { from: draft, to: withdrawn }
+                withdraw_from_request: { name: withdraw, from: withdrawal_request, to: withdrawn }
+                fallback_to_return: { from: withdrawal_request, to: new }
+```
+
+Callback mapping (existing services in `src/Services/Callbacks/` stay; a thin
+workflow subscriber delegates to them):
+
+| winzou callback | workflow event | listener behavior |
+|---|---|---|
+| updated_changelog_on_cancel | `workflow.return_status.completed.cancel` | delegate to UpdatedChangelogOnCancel |
+| updated_changelog_on_complete | `workflow.return_status.completed.complete` | delegate to UpdatedChangelogOnComplete |
+| withdrawal_request_notifier | `workflow.return_status.completed.request_withdrawal` | delegate to WithdrawalRequestNotifier |
+| withdrawal_instant_notifier (withdraw from draft) | `workflow.return_status.completed.withdraw` | if transition froms == [draft]: WithdrawalCompletedNotifier::onWithdraw |
+| withdrawal_approved_notifier (withdraw from withdrawal_request) | same event | if froms == [withdrawal_request]: WithdrawalResolutionNotifier::onConfirmWithdrawal |
+| withdrawal_resolution_fallback | `workflow.return_status.completed.fallback_to_return` | delegate to WithdrawalResolutionNotifier::onFallbackToReturn |
+
+- [ ] Add the workflow config and the subscriber (`src/Workflow/`), wire via XML
+      services per ADR 0003.
+- [ ] Replace `SM\Factory\FactoryInterface` injections with
+      `Sylius\Abstraction\StateMachine\StateMachineInterface` in:
+      `src/Controller/AdminWithdrawalConfirmController.php`,
+      `src/Controller/ReturnController.php`,
+      `src/Controller/WithdrawalController.php`,
+      `src/Services/Withdrawal/OrderWithdrawalProcessor.php`.
+- [ ] Fix latent bug: `src/Controller/ReturnController.php` (around line 164) passes
+      `OrderReturnInterface::STATUS_NEW` where `TRANSITION_NEW` is intended (works
+      today only because both strings are "new").
+- [ ] Verify whether `sylius_state_machine_abstraction.graphs_to_adapters_mapping`
+      needs an explicit `return_status: symfony_workflow` entry.
+- [ ] Smoke-test the `_sylius.state_machine` transition routes in admin routing
+      (cancel, complete, fallback_to_return).
+- [ ] ADR `docs/adr-log/0013-symfony-workflow-state-machine.md` superseding 0004.
+
+Definition of done: no winzou config remains; `bin/console workflow:dump return_status`
+shows the graph; unit tests cover the subscriber (both `withdraw` origins); a functional
+smoke drives draft -> new -> completed and draft -> withdrawal_request -> withdrawn and
+asserts changelog/notifier side effects.
+
+### Phase 5: resource layer: routing, grids, DI, doctrine
+
+Goal: all plugin routes register, grids load, doctrine schema and migrations valid.
+No template work yet.
+
+- [ ] Resource routing (`src/Resources/config/routing/{admin,shop}_routing.yml`):
+      verify `type: sylius.resource` YAML routing is still loaded (expected: yes);
+      update `templates: "@SyliusAdmin\Crud"` to the Sylius 2 crud template value
+      (DISCOVER from vendor SyliusAdminBundle routing).
+- [ ] Grids (`src/Resources/config/grids/*.yml`, 5 files): audit for the removed
+      `entities` filter (replace with `entity` + `options.fields`); audit action and
+      field types against the Sylius 2 grid bundle.
+- [ ] DI (`src/Resources/config/services/*.xml`): services are private by default in
+      Sylius 2; ensure controllers are public or tagged `controller.service_arguments`;
+      replace any injection of now-private Sylius services with official aliases.
+- [ ] Doctrine: XML mapped superclasses stay (ORM 2.x); verify `gedmo:timestampable`
+      against the resolved gedmo version; run `doctrine:migrations:migrate` and
+      `doctrine:schema:validate`; add a new migration only if diffs appear.
+- [ ] Security (`src/Security/`): verify voter registration and the guest auth-code
+      flow against the regenerated test app `security.yaml` (firewall names changed).
+
+Definition of done: `bin/console debug:router | grep madcoders` lists all routes; all
+five grids load without exception; migrations plus schema validate clean; `fixtures`
+CI gate removed if fixtures already load.
+
+### Phase 6: admin UI: twig hooks + Tabler rewrite
+
+Goal: all admin pages render on the Bootstrap/Tabler admin; every `sylius_ui.events`
+usage replaced with sylius/twig-hooks; menus work. Largest single work item.
+
+Hook mapping table. OWN = plugin-defined hook. DISCOVER = exact Sylius 2.2 hook name
+must be read from vendor templates
+(`vendor/sylius/sylius/src/Bundle/AdminBundle/templates/**`), never guessed; verify
+with `bin/console debug:twig-hooks`.
+
+| Sylius 1 event / block | Sylius 2.2 target |
+|---|---|
+| `sylius.admin.product.tab_details` block `madcoders_rma_non_returnable` (`src/Resources/views/Admin/Product/_nonReturnable.html.twig`) | DISCOVER: product create AND update form hooks; hookable template for the checkbox row |
+| `sylius.admin.order.show.after_content` (RMA panel on order show) | DISCOVER: order show content hook |
+| `madcoders_rma.admin.order_return.show.content` + `_legacySonataEvent` sub-blocks | OWN hook `madcoders_rma.admin.order_return.show.content` with hookables; delete the bridges |
+| `madcoders_rma.admin.configuration.content` + bridges | OWN hook; delete the bridges |
+| `sylius_template_event()` in `Admin/Return/show.html.twig`, `Admin/Configuration/show.html.twig` | replace with `{% hook 'madcoders_rma...' %}` |
+
+- [ ] Rewrite ~40 templates under `src/Resources/views/Admin/**` plus `BulkAction/`
+      and `credits.html.twig`: extend the new `@SyliusAdmin` base layout (DISCOVER),
+      SemanticUI to Tabler markup, `ux_icon` usage, grid custom field templates
+      (`Admin/Return/Grid/Field/*`), form themes for `Admin/Reason/_form.html.twig`
+      and `Admin/Consent/_form.html.twig`.
+- [ ] Menus: `src/Ui/Menu/AdminMenuListener.php` (`sylius.menu.admin.main`): verify
+      event survives; update icon names and section placement.
+- [ ] Routing vars: Tabler icon names; verify `vars.subheader` is still consumed.
+- [ ] Inventory Behat selector coupling (grep `tests/Behat` for SemanticUI CSS
+      selectors) to size the P8 rewrite.
+- [ ] Restore or rewrite relevant `tests/Application/templates/bundles/` overrides.
+- [ ] ADR `docs/adr-log/0014-twig-hooks-presentation.md` superseding the sylius_ui
+      parts of 0006.
+
+Definition of done: manual admin walkthrough clean (returns index/show, reasons CRUD,
+consents CRUD, configuration page, product form shows the non-returnable checkbox,
+order show displays the RMA panel); no Twig errors in the log; admin Behat suites pass
+locally even though the CI gate is still off.
+
+### Phase 7: shop UI + emails + PDF
+
+Goal: guest and account return flows render on the new shop frontend; all emails send;
+PDF generation works or is feature-flagged off.
+
+- [ ] Shop templates (`src/Resources/views/{Auth,Return,Withdrawal,Shop}/**`): extend
+      the Sylius 2.2 shop layout and account layout (DISCOVER paths), Bootstrap markup.
+- [ ] Shop hooks: `sylius.shop.layout.footer` block -> DISCOVER footer hook;
+      `madcoders_rma.shop.account.order_return.show.subcontent` -> OWN hook, delete
+      the two `_legacySonataEvent` bridges; replace `sylius_template_event()` in
+      `src/Resources/views/Shop/Return/Account/show.html.twig`.
+- [ ] Account menu: `src/Ui/Menu/AccountMenuListener.php` (`sylius.menu.shop.account`):
+      verify event and signature.
+- [ ] Emails: verify sender API; rewrite email templates in
+      `src/Resources/views/Email/` against the Sylius 2 email layout; confirm subjects
+      and translation keys.
+- [ ] PDF: verify knp-snappy-bundle boots under the resolved Symfony version and
+      wkhtmltopdf renders the rewritten template. If broken: keep the ADR 0011 feature
+      flag off and open a follow-up issue for a Gotenberg/dompdf replacement.
+- [ ] Twig extensions in `src/Twig/` feeding these views: verify output fragments
+      against the new markup.
+
+Definition of done: manual walkthrough clean (guest auth-code flow, return submission,
+withdrawal request and confirm, account return list/show, footer link); all emails
+render without template errors via null/Mailhog transport; PDF generated or flagged
+off with an issue.
+
+### Phase 8: fixtures, behat, full CI, docs, release
+
+- [ ] Fixtures: `make fixtures-test` green against the Sylius 2.2 default suite plus
+      plugin fixtures.
+- [ ] Behat: update `behat.yml.dist`, contexts and page objects (SemanticUI selectors
+      to Tabler/Bootstrap); verify MockerContainer usage in the test kernel; all
+      feature files pass non-JS.
+- [ ] CI: remove all 2.0 gating; push triggers list `1.0, 1.1, 1.2, 1.3, 2.0, master,
+      main`; consider a PHP 8.3 / Symfony 7 matrix axis.
+- [ ] README: requirements table (PHP ^8.2, Sylius ^2.2, Symfony ^6.4 || ^7),
+      install instructions per the new skeleton.
+- [ ] UPGRADE.md: "Upgrading from 1.x to 2.0" section: workflow migration guide for
+      integrators, sylius_ui event names to twig hook names table, removed
+      `_legacySonataEvent` bridge events, template override path changes.
+- [ ] CHANGELOG.md: `2.0.0-rc.1` entry (keep-a-changelog).
+- [ ] Verify the forward-merge checklist above is complete.
+- [ ] Tag `v2.0.0-rc.1` from `2.0`.
+
+Definition of done: all four CI jobs green on `2.0` with no gating; docs merged;
+rc tag published.
+
+## What stays as-is
+
+| Asset | Verdict |
+|---|---|
+| XML doctrine mapped superclasses (`src/Resources/config/doctrine/*.orm.xml`) | Stays. ORM 2.x in Sylius 2.2. Verify gedmo XML schema. |
+| YAML grids | Stay, with `entities` -> `entity` filter audit and Tabler field templates. |
+| `Configuration.php` resource tree | Mostly stays; remove `options` nodes; re-verify against ResourceBundle in 2.2. |
+| `type: sylius.resource` YAML routing | Stays (verify at P5); `templates:` value changes. |
+| SenderInterface mailer wrappers + `sylius_mailer.emails` | Likely stays; verify at P2 compile. |
+| XML service wiring (ADR 0003) | Stays; adjust for private-by-default services. |
+| `SyliusPluginTrait`, `AbstractResourceExtension`, `PrependDoctrineMigrationsTrait` | Stay; verify versions at P2. |
+| Existing migrations in `src/Migrations` | Stay (1.x schema history); verify against dbal ^3.9. |
+| SemanticUI templates, `sylius_ui.events`, `_legacySonataEvent`, winzou config | Go. |
+
+## Temporarily disabled ledger
+
+Everything disabled to keep the container compiling must be listed here and the list
+must be EMPTY before `v2.0.0-rc.1`.
+
+| Item | Disabled in | Restored in | Status |
+|---|---|---|---|
+| (none yet) | | | |
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Behat page objects coupled to SemanticUI selectors (hidden rewrite cost) | High | Selector inventory during P6; rewrite suites per feature area; behat gate stays off until P8 |
+| knp-snappy/wkhtmltopdf incompatible or renders Bootstrap templates badly | Medium | ADR 0011 feature flag as kill switch; time-boxed verify in P7; follow-up issue for Gotenberg/dompdf |
+| Wrong twig hook names | Medium | DISCOVER rule: read vendor templates, verify with `debug:twig-hooks`, never guess |
+| MockerContainer or friends-of-behat stack incompatible with Symfony 7 kernel | Medium | Pin Symfony ^6.4 first (allowed by Sylius 2.2); move to 7.x in a later minor |
+| In-flight 1.3 fixes missed on 2.0 | Medium | Forward-merge checklist above, checked before rc tag |
+| phpstan 2.x vs Sylius extension expectations | Low | Keep 2.x; drop a conflicting extension before downgrading phpstan |
+| Gedmo timestampable XML with newer gedmo/doctrine | Low | `schema:validate` in P5; fall back to explicit lifecycle callbacks |
+| Two same-named `withdraw` workflow transitions behaving unexpectedly in `can()` | Low | P4 unit tests for both origins; matches winzou semantics |

--- a/docs/upgrade-sylius-2/ROADMAP.md
+++ b/docs/upgrade-sylius-2/ROADMAP.md
@@ -67,9 +67,10 @@ removed per phase:
 
 - [x] Cut `2.0` from `1.3` tip and push (exact copy of `1c8525a`).
 - [x] Commit this roadmap.
-- [ ] CI: add `2.0` to push triggers; gate heavy jobs for the 2.0 line.
-- [ ] GitHub issues for phases 2 to 8 (label `sylius-2`, milestone `2.0.0`).
-- [ ] Phase 2 groundwork: rewritten `composer.json` targeting `sylius/sylius ^2.2`.
+- [x] CI: add `2.0` to push triggers; gate heavy jobs for the 2.0 line.
+- [x] GitHub issues for phases 2 to 8 (label `sylius-2`, milestone `2.0.0`): #35 to #41.
+- [x] Phase 2 groundwork: rewritten `composer.json` targeting `sylius/sylius ^2.2`
+      (verified to resolve to Sylius 2.2.6 on Symfony 7.4).
 
 Definition of done: `origin/2.0` exists at `1c8525a`; this PR merged; CI completes
 without red on the PR (gated jobs skipped); 7 phase issues open.


### PR DESCRIPTION
## Summary

Kicks off the Sylius 2.2 upgrade on the new `2.0` release branch (phase 1 of the roadmap, plus the composer part of phase 2):

- **Roadmap**: adds `docs/upgrade-sylius-2/ROADMAP.md`, the living document for the 8-phase migration (dependency graph, per-phase tasks and definitions of done, state machine and twig-hooks mapping tables, temporarily-disabled ledger, risk register, forward-merge checklist for in-flight 1.x fixes).
- **CI**: adds `2.0` to push triggers and gates the heavy jobs (`unit`, `fixtures`, `behat`, and the analysis steps of `static`) off for the 2.0 line so the branch stays green with reduced checks while the plugin cannot yet boot on Sylius 2. `composer validate` runs on every push. Each gate carries a `TODO(sylius-2)` note naming the phase that removes it.
- **Composer**: `sylius/sylius: ^2.2` with dev tooling aligned to PluginSkeleton 2.0 (PHPUnit ^10.5, Behat ^3.16, webpack-encore-bundle ^2.2, symfony/flex, symfony/* `^6.4 || ^7.1`), branch alias `dev-2.0: 2.0-dev`. Constraints verified to resolve: Sylius 2.2.6 on Symfony 7.4 with API Platform 4.3 and sylius/twig-hooks.
- **Changelog**: `[Unreleased]` note that the Sylius 2 line begins.

## Notes for reviewers

- The `2.0` branch was pushed as an exact copy of the `1.3` tip (`1c8525a`). Nothing is installable on this branch until phase 2 (test application regeneration) completes; that is expected and recorded in the roadmap.
- Open fixes for issues #26, #27, #28 are not in this base; the roadmap carries a forward-merge checklist that must be complete before `v2.0.0-rc.1`.

## Verification

- `composer validate` passes; `composer update --no-install` resolves the full dependency tree against Sylius 2.2.6.
- Gated CI jobs skip on this PR (base `2.0`); the `static` job still validates composer.json.