### PR TITLE
release: 1.3.0-rc.4 (security hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), and commi
 
 ## [Unreleased]
 
+## [1.3.0-rc.4] - 2026-07-05
+
+Fourth release candidate for the 1.3 line, a security hardening pass over the return and
+withdrawal flows on top of rc.3.
+
+### Security
+
+- **Harden the RMA auth-code against brute force**: the emailed code is the single secret gating
+  the return/withdrawal flow, and a successful guess can trigger an irreversible order cancellation
+  via the instant-withdrawal path. The attempt limit is now a real lockout (verification hard-stops
+  once attempts reach the maximum, before evaluating the guess), the code is invalidated on lockout,
+  expiry and successful one-time use (so its hash cannot be replayed), it is generated with
+  `random_int()` over an 8-digit keyspace and compared with `hash_equals()` (constant time). The
+  code-request and verification endpoints are rate limited per client IP and order number by an
+  in-plugin PSR-6 cache-backed throttler (no extra Composer dependency, only a cache pool),
+  returning HTTP 429 with a `Retry-After` header when exceeded; the limiter sits behind the
+  `madcoders_rma.limit_auth_attempts` feature flag (env `MADCODERS_RMA_LIMIT_AUTH_ATTEMPTS`,
+  default on) ([#26](https://github.com/mad-coders/sylius-rma-plugin/issues/26)).
+- **Send the return document to the order's customer, not a customer-supplied address**: the
+  editable `customerEmail` form field was used verbatim as the recipient of the return-form e-mail
+  and its attached PDF (which carries the customer's name, address and order lines), so a customer
+  could redirect their own return document to an arbitrary address. The recipient is now re-derived
+  from the order's customer and the submitted value is never read for the recipient; `NotBlank` and
+  `Email` constraints are added on the field for input hygiene
+  ([#28](https://github.com/mad-coders/sylius-rma-plugin/issues/28)).
+- **Authorize the withdrawal success page**: `WithdrawalController::successIndex` rendered an
+  `OrderReturn` looked up by its predictable return number (`RMA-{orderNumber}-{n}`) with no
+  authorization check, an enumeration oracle for return existence and status. It is now gated on the
+  same `OrderReturnVoter` check as the sibling withdrawal actions
+  ([#27](https://github.com/mad-coders/sylius-rma-plugin/issues/27)).
+
 ## [1.3.0-rc.3] - 2026-06-23
 
 Third release candidate for the 1.3 line, making the RMA e-mails self-contained, branded and


### PR DESCRIPTION
## Summary

Fourth release candidate for the 1.3 line. Documents the three security fixes already merged into `1.3` since `1.3.0-rc.3` (#27, #28, #26) and stamps the CHANGELOG for the release.

This PR contains only the CHANGELOG entry; the fixes themselves landed in PRs #31, #32, #33.

### Security fixes in this RC

- **#26** Harden the RMA auth-code against brute force (real lockout, one-time invalidation, `random_int()` + 8-digit keyspace, `hash_equals()`, per-IP/order rate limiting behind `madcoders_rma.limit_auth_attempts`).
- **#28** Send the return document to the order's customer, not the customer-editable `customerEmail` field (recipient re-derived from the order; `NotBlank`/`Email` constraints added).
- **#27** Authorize the withdrawal success page (gated on `OrderReturnVoter`, closing a return-number enumeration oracle).

## After merge

- Tag `1.3.0-rc.4` on the merge commit (matches the rc.2/rc.3 lightweight-tag-on-merge convention).
- Upmerge `1.3` into `2.0` so these security fixes carry into the Sylius 2 line (separate PR; ticks the forward-merge checklist in `docs/upgrade-sylius-2/ROADMAP.md`).

## Verification

- `git log 1.3.0-rc.3..1.3` shows exactly the three security fixes plus a rector style commit.
- CHANGELOG entry renders under a `### Security` heading; no em/en dashes.